### PR TITLE
other: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+    Thank you for contributing to our project, JuleLang!
+    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.
+
+    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
+-->
+
+### Description
+
+<!-- Describe what this PR introduces. -->
+<!-- If any, link any issue that this PR solves. -->
+
+### Checklist
+
+<!-- Check the boxes below to ensure you have completed the checklist. -->
+
+- [ ] A description of the changes in this PR is mentioned above.
+- [ ] All the new and existing test pass.
+- [ ] The code follows the code style and conventions of the project.
+- [ ] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
+- [ ] I have read the whole [Contributing guidelines](https://jule.dev/pages/contributing.html) of the project and its resources/related pages.
+
+### Screenshots (if any)
+
+<!--
+
+If any, add screenshots to help explain your changes.
+Remove these comments to highlight the screenshots in the PR.
+
+|      Original       |      Updated       |
+| :-----------------: | :----------------: |
+| original screenshot | updated screenshot |
+
+-->
+
+### Note to reviewers
+
+<!-- Please add a one-line description for developers or pull request viewers, if any. -->


### PR DESCRIPTION
Things added/changed:

- Add PR template.
  - Closes #11.
  - The PR template is not visible here due that it isn't in the original repository. Once it's merged, it should be fully visible and working.
