### PR TITLE
other: update shebang in `build.sh` for better platform support

### DIFF
--- a/src/julec/build.sh
+++ b/src/julec/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/bash
 # Copyright 2023 The Jule Programming Language.
 # Use of this source code is governed by a BSD 3-Clause
 # license that can be found in the LICENSE file.


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

The PR updates the build script shebang. The current shell path would not be found on e.g. macOS. The update path is found on linux and macOS by default. 

It also moves towards using the default login shell on most linux oses `bash` instead of Bourne Shell `sh`. This second change is not strictly necessary at that point as it doesn't solve a concrete issue or brings an improvement, it just uses a more common specification.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.
