### PR TITLE
api: use `constexpr` instead of `inline constexpr` for functions

### DIFF
--- a/api/any.hpp
+++ b/api/any.hpp
@@ -251,7 +251,7 @@ namespace jule
         }
 
         template <typename T>
-        inline constexpr jule::Bool operator!=(const T &expr) const
+        constexpr jule::Bool operator!=(const T &expr) const
         {
             return !this->operator==(expr);
         }
@@ -279,12 +279,12 @@ namespace jule
             return !this->operator==(other);
         }
 
-        inline constexpr jule::Bool operator==(std::nullptr_t) const noexcept
+        constexpr jule::Bool operator==(std::nullptr_t) const noexcept
         {
             return !this->data;
         }
 
-        inline constexpr jule::Bool operator!=(std::nullptr_t) const noexcept
+        constexpr jule::Bool operator!=(std::nullptr_t) const noexcept
         {
             return !this->operator==(nullptr);
         }

--- a/api/array.hpp
+++ b/api/array.hpp
@@ -48,22 +48,22 @@ namespace jule
         typedef Item *Iterator;
         typedef const Item *ConstIterator;
 
-        inline constexpr Iterator begin(void) noexcept
+        constexpr Iterator begin(void) noexcept
         {
             return this->buffer;
         }
 
-        inline constexpr ConstIterator begin(void) const noexcept
+        constexpr ConstIterator begin(void) const noexcept
         {
             return this->buffer;
         }
 
-        inline constexpr Iterator end(void) noexcept
+        constexpr Iterator end(void) noexcept
         {
             return this->begin() + N;
         }
 
-        inline constexpr ConstIterator end(void) const noexcept
+        constexpr ConstIterator end(void) const noexcept
         {
             return this->begin() + N;
         }
@@ -132,12 +132,12 @@ namespace jule
                 0, N);
         }
 
-        inline constexpr jule::Int len(void) const noexcept
+        constexpr jule::Int len(void) const noexcept
         {
             return N;
         }
 
-        inline constexpr jule::Bool empty(void) const noexcept
+        constexpr jule::Bool empty(void) const noexcept
         {
             return N == 0;
         }
@@ -157,14 +157,14 @@ namespace jule
             return true;
         }
 
-        inline constexpr jule::Bool operator!=(const jule::Array<Item, N> &src) const
+        constexpr jule::Bool operator!=(const jule::Array<Item, N> &src) const
         {
             return !this->operator==(src);
         }
 
         // Returns element by index.
         // Not includes safety checking.
-        inline constexpr Item &__at(const jule::Int &index) const noexcept
+        constexpr Item &__at(const jule::Int &index) const noexcept
         {
             return this->buffer[index];
         }

--- a/api/fn.hpp
+++ b/api/fn.hpp
@@ -84,7 +84,7 @@ namespace jule
 #endif
         }
 
-        inline constexpr jule::Uintptr addr(void) const noexcept
+        constexpr jule::Uintptr addr(void) const noexcept
         {
             return this->_addr;
         }
@@ -104,22 +104,22 @@ namespace jule
             this->buffer = function;
         }
 
-        inline constexpr jule::Bool operator==(const Fn<Function> &fn) const noexcept
+        constexpr jule::Bool operator==(const Fn<Function> &fn) const noexcept
         {
             return this->addr() == fn.addr();
         }
 
-        inline constexpr jule::Bool operator!=(const Fn<Function> &fn) const noexcept
+        constexpr jule::Bool operator!=(const Fn<Function> &fn) const noexcept
         {
             return !this->operator==(fn);
         }
 
-        inline constexpr jule::Bool operator==(std::nullptr_t) const noexcept
+        constexpr jule::Bool operator==(std::nullptr_t) const noexcept
         {
             return this->buffer == nullptr;
         }
 
-        inline constexpr jule::Bool operator!=(std::nullptr_t) const noexcept
+        constexpr jule::Bool operator!=(std::nullptr_t) const noexcept
         {
             return !this->operator==(nullptr);
         }

--- a/api/map.hpp
+++ b/api/map.hpp
@@ -55,27 +55,27 @@ namespace jule
                 this->buffer.insert(pair);
         }
 
-        inline constexpr auto begin(void) noexcept
+        constexpr auto begin(void) noexcept
         {
             return this->buffer.begin();
         }
 
-        inline constexpr auto begin(void) const noexcept
+        constexpr auto begin(void) const noexcept
         {
             return this->buffer.begin();
         }
 
-        inline constexpr auto end(void) noexcept
+        constexpr auto end(void) noexcept
         {
             return this->buffer.end();
         }
 
-        inline constexpr auto end(void) const noexcept
+        constexpr auto end(void) const noexcept
         {
             return this->buffer.end();
         }
 
-        inline constexpr void clear(void) noexcept
+        constexpr void clear(void) noexcept
         {
             this->buffer.clear();
         }
@@ -98,12 +98,12 @@ namespace jule
             return keys;
         }
 
-        inline constexpr jule::Bool has(const Key &key) const
+        constexpr jule::Bool has(const Key &key) const
         {
             return this->buffer.find(key) != this->end();
         }
 
-        inline constexpr jule::Int len(void) const noexcept
+        constexpr jule::Int len(void) const noexcept
         {
             return this->buffer.size();
         }
@@ -113,12 +113,12 @@ namespace jule
             this->buffer.erase(key);
         }
 
-        inline constexpr jule::Bool operator==(const std::nullptr_t) const noexcept
+        constexpr jule::Bool operator==(const std::nullptr_t) const noexcept
         {
             return this->buffer.empty();
         }
 
-        inline constexpr jule::Bool operator!=(const std::nullptr_t) const noexcept
+        constexpr jule::Bool operator!=(const std::nullptr_t) const noexcept
         {
             return !this->operator==(nullptr);
         }

--- a/api/misc.hpp
+++ b/api/misc.hpp
@@ -65,7 +65,7 @@ namespace jule
         }
 
         template <typename T, typename Denominator>
-        inline constexpr auto unsafe_div(
+        constexpr auto unsafe_div(
 #ifndef __JULE_ENABLE__PRODUCTION
             const char *file,
 #endif
@@ -75,7 +75,7 @@ namespace jule
         }
 
         template <typename T, typename Denominator>
-        inline constexpr auto unsafe_mod(
+        constexpr auto unsafe_mod(
 #ifndef __JULE_ENABLE__PRODUCTION
             const char *file,
 #endif

--- a/api/slice.hpp
+++ b/api/slice.hpp
@@ -213,22 +213,22 @@ namespace jule
         typedef Item *Iterator;
         typedef const Item *ConstIterator;
 
-        inline constexpr Iterator begin(void) noexcept
+        constexpr Iterator begin(void) noexcept
         {
             return this->_slice;
         }
 
-        inline constexpr ConstIterator begin(void) const noexcept
+        constexpr ConstIterator begin(void) const noexcept
         {
             return this->_slice;
         }
 
-        inline constexpr Iterator end(void) noexcept
+        constexpr Iterator end(void) noexcept
         {
             return this->_slice + this->_len;
         }
 
-        inline constexpr ConstIterator end(void) const noexcept
+        constexpr ConstIterator end(void) const noexcept
         {
             return this->_slice + this->_len;
         }
@@ -296,12 +296,12 @@ namespace jule
                 this->len());
         }
 
-        inline constexpr jule::Int len(void) const noexcept
+        constexpr jule::Int len(void) const noexcept
         {
             return this->_len;
         }
 
-        inline constexpr jule::Int cap(void) const noexcept
+        constexpr jule::Int cap(void) const noexcept
         {
             return this->_cap;
         }
@@ -348,17 +348,17 @@ namespace jule
             return true;
         }
 
-        inline constexpr jule::Bool operator!=(const jule::Slice<Item> &src) const
+        constexpr jule::Bool operator!=(const jule::Slice<Item> &src) const
         {
             return !this->operator==(src);
         }
 
-        inline constexpr jule::Bool operator==(const std::nullptr_t) const noexcept
+        constexpr jule::Bool operator==(const std::nullptr_t) const noexcept
         {
             return !this->_slice;
         }
 
-        inline constexpr jule::Bool operator!=(const std::nullptr_t) const noexcept
+        constexpr jule::Bool operator!=(const std::nullptr_t) const noexcept
         {
             return !this->operator==(nullptr);
         }

--- a/api/str.hpp
+++ b/api/str.hpp
@@ -63,22 +63,22 @@ namespace jule
         typedef jule::U8 *Iterator;
         typedef const jule::U8 *ConstIterator;
 
-        inline constexpr Iterator begin(void) noexcept
+        constexpr Iterator begin(void) noexcept
         {
             return static_cast<Iterator>(&this->buffer[0]);
         }
 
-        inline constexpr ConstIterator begin(void) const noexcept
+        constexpr ConstIterator begin(void) const noexcept
         {
             return static_cast<ConstIterator>(&this->buffer[0]);
         }
 
-        inline constexpr Iterator end(void) noexcept
+        constexpr Iterator end(void) noexcept
         {
             return static_cast<Iterator>(&this->buffer[this->len()]);
         }
 
-        inline constexpr ConstIterator end(void) const noexcept
+        constexpr ConstIterator end(void) const noexcept
         {
             return static_cast<ConstIterator>(&this->buffer[this->len()]);
         }
@@ -136,22 +136,22 @@ namespace jule
                 0, this->len());
         }
 
-        inline constexpr jule::Int len(void) const noexcept
+        constexpr jule::Int len(void) const noexcept
         {
             return this->buffer.length();
         }
 
-        inline constexpr jule::Bool empty(void) const noexcept
+        constexpr jule::Bool empty(void) const noexcept
         {
             return this->buffer.empty();
         }
 
-        inline constexpr operator char *(void) const noexcept
+        constexpr operator char *(void) const noexcept
         {
             return const_cast<char *>(reinterpret_cast<const char *>(this->buffer.c_str()));
         }
 
-        inline constexpr operator const char *(void) const noexcept
+        constexpr operator const char *(void) const noexcept
         {
             return reinterpret_cast<const char *>(this->buffer.c_str());
         }
@@ -192,7 +192,7 @@ namespace jule
 
         // Returns element by index.
         // Not includes safety checking.
-        inline constexpr jule::U8 &__at(const jule::Int &index) noexcept
+        constexpr jule::U8 &__at(const jule::Int &index) noexcept
         {
             return this->buffer[index];
         }

--- a/api/trait.hpp
+++ b/api/trait.hpp
@@ -238,22 +238,22 @@ namespace jule
             this->__get_copy(src);
         }
 
-        inline constexpr jule::Bool operator==(const jule::Trait<Mask> &src) const noexcept
+        constexpr jule::Bool operator==(const jule::Trait<Mask> &src) const noexcept
         {
             return this->data.alloc == this->data.alloc;
         }
 
-        inline constexpr jule::Bool operator!=(const jule::Trait<Mask> &src) const noexcept
+        constexpr jule::Bool operator!=(const jule::Trait<Mask> &src) const noexcept
         {
             return !this->operator==(src);
         }
 
-        inline constexpr jule::Bool operator==(std::nullptr_t) const noexcept
+        constexpr jule::Bool operator==(std::nullptr_t) const noexcept
         {
             return this->data.alloc == nullptr;
         }
 
-        inline constexpr jule::Bool operator!=(std::nullptr_t) const noexcept
+        constexpr jule::Bool operator!=(std::nullptr_t) const noexcept
         {
             return !this->operator==(nullptr);
         }


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

While browsing though the C++ code I have noticed that many functions have `inline constexpr` specifiers. According to [C++ reference for `constexpr`](https://en.cppreference.com/w/cpp/language/constexpr): _A constexpr specifier used in a function or [static](https://en.cppreference.com/w/cpp/language/static) data member(since C++17) declaration implies inline_.

[Build](https://github.com/vil02/jule/actions/runs/7680919760) and [tests](https://github.com/vil02/jule/actions/runs/7680919762) pass on _my end_.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Make all `inline constexpr` functions `constexpr`.