### PR TITLE
api: fix `jule::Trait<Mask>::operator==`

### DIFF
--- a/api/trait.hpp
+++ b/api/trait.hpp
@@ -240,7 +240,7 @@ namespace jule
 
         constexpr jule::Bool operator==(const jule::Trait<Mask> &src) const noexcept
         {
-            return this->data.alloc == this->data.alloc;
+            return this->data.alloc == src.data.alloc;
         }
 
         constexpr jule::Bool operator!=(const jule::Trait<Mask> &src) const noexcept


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

There seems to be a bug in the current implementation of [`jule::Trait<Mask>::operator==`](https://github.com/julelang/jule/blob/60ec0a110879554fcf70ca838cd98f1b6d715dd9/api/trait.hpp#L243). Otherwise, I would suggest to always return `true`.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Fixes implementation of `jule::Trait<Mask>::operator==`.
