### PR TITLE
api: add missing `return` to `Trait::operator T(void)`

### DIFF
--- a/api/trait.hpp
+++ b/api/trait.hpp
@@ -206,7 +206,7 @@ namespace jule
         template <typename T>
         inline operator T(void) noexcept
         {
-            this->cast<T>(
+            return this->cast<T>(
 #ifndef __JULE_ENABLE__PRODUCTION
                 "/api/trait.hpp"
 #endif


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->
There is a missing `return` statement in this line: https://github.com/julelang/jule/blob/fb428b5a8835f77bc0b52d314784edd294c99fc1/api/trait.hpp#L209

This PR fixes that.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Add missing `return` to `Trait::operator T(void)`.
