### PR TITLE
api: use const reference when decoding `std::vector<jule::I32>`

### DIFF
--- a/api/utf16.hpp
+++ b/api/utf16.hpp
@@ -32,7 +32,7 @@ namespace jule
     constexpr signed int UTF16_MAX_RUNE = 1114111;
 
     inline jule::I32 utf16_decode_rune(const jule::I32 r1, const jule::I32 r2) noexcept;
-    std::vector<jule::I32> utf16_decode(const std::vector<jule::I32> s);
+    std::vector<jule::I32> utf16_decode(const std::vector<jule::I32> &s);
     std::vector<jule::I32> utf8_to_runes(const std::string &s) noexcept;
     std::string utf16_to_utf8_str(const wchar_t *wstr, const std::size_t len);
     std::tuple<jule::I32, jule::I32> utf16_encode_rune(jule::I32 r);


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

Altough [`utf16_decode` for `std::vector<jule::I32>`](https://github.com/julelang/jule/blob/096e109ba5ae1bfb9d4ba462fad84802d384641f/api/utf16.hpp#L35) is not yet defined, I think the input of that function should be passed by _const reference_.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Avoid passing `std::vector<jule::I32>` by value.