### PR TITLE
api: remove `const` from return type of `DynamicType::to_str`

### DIFF
--- a/api/any.hpp
+++ b/api/any.hpp
@@ -46,7 +46,7 @@ namespace jule
                 return *l == *r;
             }
 
-            static const jule::Str to_str(const void *alloc) noexcept
+            static jule::Str to_str(const void *alloc) noexcept
             {
                 const T *v = static_cast<const T *>(alloc);
                 return jule::to_str(*v);


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

The `const` in the return type of [`DynamicType::to_str`](https://github.com/julelang/jule/blob/7500f59ce174d89de82d13fe12679e9fa28dbd42/api/any.hpp#L49) is not only redundant but it also might cause some loss of performance.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Remove `const` from return type of `DynamicType::to_str`.
