### PR TITLE
api: fix `reinterpret_cast` is not `constexpr`

### DIFF
--- a/api/str.hpp
+++ b/api/str.hpp
@@ -146,12 +146,12 @@ namespace jule
             return this->buffer.empty();
         }
 
-        constexpr operator char *(void) const noexcept
+        operator char *(void) const noexcept
         {
             return const_cast<char *>(reinterpret_cast<const char *>(this->buffer.c_str()));
         }
 
-        constexpr operator const char *(void) const noexcept
+        operator const char *(void) const noexcept
         {
             return reinterpret_cast<const char *>(this->buffer.c_str());
         }


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->
`reinterpret_cast` cannot be used in `constexpr` context.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
`reinterpret_cast` is not `constexpr`.