### PR TITLE
api: avoid comparison of ints of different sign

### DIFF
--- a/api/utf16.hpp
+++ b/api/utf16.hpp
@@ -56,7 +56,7 @@ namespace jule
     {
         std::vector<jule::I32> a(s.size());
         jule::Int n = 0;
-        for (decltype(s.size()) i = 0; i < s.size(); ++i)
+        for (std::size_t i = 0; i < s.size(); ++i)
         {
             jule::U16 r = s[i];
             if (r < jule::UTF16_SURR1 || jule::UTF16_SURR3 <= r)
@@ -84,7 +84,7 @@ namespace jule
     {
         std::vector<jule::I32> runes;
         const char *str = s.c_str();
-        for (decltype(s.length()) index = 0; index < s.length();)
+        for (std::size_t index = 0; index < s.length();)
         {
             jule::I32 rune;
             jule::Int n;

--- a/api/utf16.hpp
+++ b/api/utf16.hpp
@@ -56,7 +56,7 @@ namespace jule
     {
         std::vector<jule::I32> a(s.size());
         jule::Int n = 0;
-        for (jule::Int i = 0; i < s.size(); ++i)
+        for (decltype(s.size()) i = 0; i < s.size(); ++i)
         {
             jule::U16 r = s[i];
             if (r < jule::UTF16_SURR1 || jule::UTF16_SURR3 <= r)
@@ -84,7 +84,7 @@ namespace jule
     {
         std::vector<jule::I32> runes;
         const char *str = s.c_str();
-        for (jule::Int index = 0; index < s.length();)
+        for (decltype(s.length()) index = 0; index < s.length();)
         {
             jule::I32 rune;
             jule::Int n;
@@ -100,7 +100,7 @@ namespace jule
                                   const std::size_t len)
     {
         std::vector<jule::U16> code_page(len);
-        for (jule::Int i = 0; i < len; ++i)
+        for (std::size_t i = 0; i < len; ++i)
             code_page[i] = static_cast<jule::U16>(wstr[i]);
         return jule::runes_to_utf8(jule::utf16_decode(code_page));
     }


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->
Comparing signed and unsigned ints can lead to all kinds of madness and it should be avoided. Please note that on two occasions I have used [`decltype`](https://en.cppreference.com/w/cpp/language/decltype), which might be an _overkill_. I can change it to `std::size_t`.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Avoid comparison of integers of different sign.
