### PR TITLE
api: use `auto` with `static_cast`

### DIFF
--- a/api/ptr.hpp
+++ b/api/ptr.hpp
@@ -90,7 +90,7 @@ namespace jule
 #ifdef __JULE_DISABLE__REFERENCE_COUNTING
             return jule::Ptr<T>::make(instance, nullptr);
 #else
-            jule::Uint *ref = new (std::nothrow) jule::Uint;
+            auto *ref = new (std::nothrow) jule::Uint;
             if (!ref)
                 jule::panic(__JULE_ERROR__MEMORY_ALLOCATION_FAILED
                             "\nruntime: memory allocation failed for reference counter of reference type");

--- a/api/utf8.hpp
+++ b/api/utf8.hpp
@@ -346,7 +346,7 @@ namespace jule
         if (len < 1)
             return std::make_tuple<jule::I32, jule::Int>(jule::UTF8_RUNE_ERROR, 0);
 
-        const jule::U8 s0 = static_cast<jule::U8>(s[0]);
+        const auto s0 = static_cast<jule::U8>(s[0]);
         const jule::U8 x = jule::utf8_first[s0];
         if (x >= jule::UTF8_AS)
         {
@@ -356,12 +356,12 @@ namespace jule
                                    1);
         }
 
-        const jule::Int sz = static_cast<jule::Int>(x & 7);
+        const auto sz = static_cast<jule::Int>(x & 7);
         const struct jule::UTF8AcceptRange accept = jule::utf8_accept_ranges[x >> 4];
         if (len < sz)
             return std::make_tuple<jule::I32, jule::Int>(jule::UTF8_RUNE_ERROR, 1);
 
-        const jule::U8 s1 = static_cast<jule::U8>(s[1]);
+        const auto s1 = static_cast<jule::U8>(s[1]);
         if (s1 < accept.lo || accept.hi < s1)
             return std::make_tuple<jule::I32, jule::Int>(jule::UTF8_RUNE_ERROR, 1);
 
@@ -371,7 +371,7 @@ namespace jule
                     static_cast<jule::I32>(s1 & jule::UTF8_MASKX),
                 2);
 
-        const jule::U8 s2 = static_cast<jule::U8>(s[2]);
+        const auto s2 = static_cast<jule::U8>(s[2]);
         if (s2 < jule::UTF8_LOCB || jule::UTF8_HICB < s2)
             return std::make_tuple<jule::I32, jule::Int>(jule::UTF8_RUNE_ERROR, 1);
 
@@ -382,7 +382,7 @@ namespace jule
                     static_cast<jule::I32>(s2 & jule::UTF8_MASKX),
                 3);
 
-        const jule::U8 s3 = static_cast<jule::U8>(s[3]);
+        const auto s3 = static_cast<jule::U8>(s[3]);
         if (s3 < jule::UTF8_LOCB || jule::UTF8_HICB < s3)
             return std::make_tuple<jule::I32, jule::Int>(jule::UTF8_RUNE_ERROR, 1);
 
@@ -398,7 +398,7 @@ namespace jule
         if (static_cast<jule::U32>(r) <= jule::UTF8_RUNE1_MAX)
             return std::vector<jule::U8>({static_cast<jule::U8>(r)});
 
-        const jule::U32 i = static_cast<jule::U32>(r);
+        const auto i = static_cast<jule::U32>(r);
         if (i < jule::UTF8_RUNE2_MAX)
         {
             return std::vector<jule::U8>({static_cast<jule::U8>(jule::UTF8_T2 | static_cast<jule::U8>(r >> 6)),


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->
In these situations, explicitly describing the type of a defined variable is redundant. I suggest to use `auto`.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Use `auto` when a variable is defined as a result of `static_cast`.