### PR TITLE
api: avoid sign conversion in `utf16_decode`

### DIFF
--- a/api/utf16.hpp
+++ b/api/utf16.hpp
@@ -55,7 +55,7 @@ namespace jule
     std::vector<jule::I32> utf16_decode(const std::vector<jule::U16> &s) noexcept
     {
         std::vector<jule::I32> a(s.size());
-        jule::Int n = 0;
+        std::size_t n = 0;
         for (std::size_t i = 0; i < s.size(); ++i)
         {
             jule::U16 r = s[i];


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description
The input type of [`operator[]`](https://en.cppreference.com/w/cpp/container/vector/operator_at) is `std::size_t`. Using a _signed_ type leads to _sign conversion_.

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Avoid sign conversion in `utf16_decode`.