### PR TITLE
api: avoid sign conversion in `utf8_to_runes`

### DIFF
--- a/api/utf16.hpp
+++ b/api/utf16.hpp
@@ -87,7 +87,7 @@ namespace jule
         for (std::size_t index = 0; index < s.length();)
         {
             jule::I32 rune;
-            jule::Int n;
+            std::size_t n;
             std::tie(rune, n) = jule::utf8_decode_rune_str(str + index,
                                                            s.length() - index);
             index += n;

--- a/api/utf8.hpp
+++ b/api/utf8.hpp
@@ -52,7 +52,7 @@ namespace jule
 
     struct UTF8AcceptRange;
     std::string runes_to_utf8(const std::vector<jule::I32> &s) noexcept;
-    std::tuple<jule::I32, jule::Int> utf8_decode_rune_str(const char *s, const jule::Int &len);
+    std::tuple<jule::I32, std::size_t> utf8_decode_rune_str(const char *s, const std::size_t len);
     std::vector<jule::U8> utf8_rune_to_bytes(const jule::I32 &r);
 
     // Definitions
@@ -340,10 +340,10 @@ namespace jule
         return buffer;
     }
 
-    std::tuple<jule::I32, jule::Int>
-    utf8_decode_rune_str(const char *s, const jule::Int &len)
+    std::tuple<jule::I32, std::size_t>
+    utf8_decode_rune_str(const char *s, const std::size_t len)
     {
-        if (len < 1)
+        if (len == 0)
             return std::make_tuple<jule::I32, jule::Int>(jule::UTF8_RUNE_ERROR, 0);
 
         const auto s0 = static_cast<jule::U8>(s[0]);
@@ -356,27 +356,27 @@ namespace jule
                                    1);
         }
 
-        const auto sz = static_cast<jule::Int>(x & 7);
+        const auto sz = static_cast<std::size_t>(x & 7);
         const struct jule::UTF8AcceptRange accept = jule::utf8_accept_ranges[x >> 4];
         if (len < sz)
-            return std::make_tuple<jule::I32, jule::Int>(jule::UTF8_RUNE_ERROR, 1);
+            return std::make_tuple<jule::I32, std::size_t>(jule::UTF8_RUNE_ERROR, 1);
 
         const auto s1 = static_cast<jule::U8>(s[1]);
         if (s1 < accept.lo || accept.hi < s1)
-            return std::make_tuple<jule::I32, jule::Int>(jule::UTF8_RUNE_ERROR, 1);
+            return std::make_tuple<jule::I32, std::size_t>(jule::UTF8_RUNE_ERROR, 1);
 
         if (sz <= 2)
-            return std::make_tuple<jule::I32, jule::Int>(
+            return std::make_tuple<jule::I32, std::size_t>(
                 (static_cast<jule::I32>(s0 & jule::UTF8_MASK2) << 6) |
                     static_cast<jule::I32>(s1 & jule::UTF8_MASKX),
                 2);
 
         const auto s2 = static_cast<jule::U8>(s[2]);
         if (s2 < jule::UTF8_LOCB || jule::UTF8_HICB < s2)
-            return std::make_tuple<jule::I32, jule::Int>(jule::UTF8_RUNE_ERROR, 1);
+            return std::make_tuple<jule::I32, std::size_t>(jule::UTF8_RUNE_ERROR, 1);
 
         if (sz <= 3)
-            return std::make_tuple<jule::I32, jule::Int>(
+            return std::make_tuple<jule::I32, std::size_t>(
                 (static_cast<jule::I32>(s0 & jule::UTF8_MASK3) << 12) |
                     (static_cast<jule::I32>(s1 & jule::UTF8_MASKX) << 6) |
                     static_cast<jule::I32>(s2 & jule::UTF8_MASKX),
@@ -384,7 +384,7 @@ namespace jule
 
         const auto s3 = static_cast<jule::U8>(s[3]);
         if (s3 < jule::UTF8_LOCB || jule::UTF8_HICB < s3)
-            return std::make_tuple<jule::I32, jule::Int>(jule::UTF8_RUNE_ERROR, 1);
+            return std::make_tuple<jule::I32, std::size_t>(jule::UTF8_RUNE_ERROR, 1);
 
         return std::make_tuple((static_cast<jule::I32>(s0 & jule::UTF8_MASK4) << 18) |
                                    (static_cast<jule::I32>(s1 & jule::UTF8_MASKX) << 12) |


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

Similar to #71. Please note the change of the signature of [`utf8_decode_rune_str`](https://github.com/julelang/jule/blob/ded1922a6768c63e5abc3d5fd795ac5eff18d881/api/utf8.hpp#L55).

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Avoid sign conversion in `utf8_to_runes`.
