### PR TITLE
api: use fixed width integer types to define jule types

### DIFF
--- a/api/types.hpp
+++ b/api/types.hpp
@@ -6,6 +6,7 @@
 #define __JULE_TYPES_HPP
 
 #include <cstddef>
+#include <cstdint>
 #include <ostream>
 
 #include "platform.hpp"
@@ -23,14 +24,14 @@ namespace jule
     typedef unsigned long long int Uintptr;
 #endif
 
-    typedef signed char I8;
-    typedef signed short int I16;
-    typedef signed long int I32;
-    typedef signed long long int I64;
-    typedef unsigned char U8;
-    typedef unsigned short int U16;
-    typedef unsigned long int U32;
-    typedef unsigned long long int U64;
+    using I8 = std::int8_t;
+    using I16 = std::int16_t;
+    using I32 = std::int32_t;
+    using I64 = std::int64_t;
+    using U8 = std::uint8_t;
+    using U16 = std::uint16_t;
+    using U32 = std::uint32_t;
+    using U64 = std::uint64_t;
     typedef float F32;
     typedef double F64;
     typedef bool Bool;


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

Since the true size of _basic_ integer types might be _everything_ depended, I suggest to define jule integer types using the [_fixed with integer types_](https://en.cppreference.com/w/cpp/types/integer).


### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Use fixed width integer types to define jule types.