### PR TITLE
ci: add GCC for tests

### DIFF
--- a/.github/workflows/build_clang_macos.yml
+++ b/.github/workflows/build_clang_macos.yml
@@ -1,0 +1,16 @@
+name: Build [Clang] - macOS
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Panquesito7/setup-jule@v1.1.3
+        with:
+          version: dev
+          directory: .
+          add-to-path: true
+
+      - name: Build JuleC
+        run: |
+          julec --compiler clang src/julec

--- a/.github/workflows/build_clang_ubuntu.yml
+++ b/.github/workflows/build_clang_ubuntu.yml
@@ -13,4 +13,4 @@ jobs:
 
       - name: Build JuleC
         run: |
-          julec src/julec
+          julec --compiler clang src/julec

--- a/.github/workflows/build_clang_ubuntu.yml
+++ b/.github/workflows/build_clang_ubuntu.yml
@@ -2,7 +2,7 @@ name: Build [Clang] - Ubuntu
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: $ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: Panquesito7/setup-jule@v1.1.3

--- a/.github/workflows/build_clang_ubuntu.yml
+++ b/.github/workflows/build_clang_ubuntu.yml
@@ -1,4 +1,4 @@
-name: Buildp
+name: Build [Clang] - Ubuntu
 on: [push, pull_request]
 jobs:
   build:

--- a/.github/workflows/build_clang_ubuntu.yml
+++ b/.github/workflows/build_clang_ubuntu.yml
@@ -1,11 +1,8 @@
-name: Build
+name: Buildp
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest]
+    runs-on: $ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: Panquesito7/setup-jule@v1.1.3

--- a/.github/workflows/build_gcc_macos.yml
+++ b/.github/workflows/build_gcc_macos.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Build IR
         run: |
-          julec --t src/julec
+          julec -t src/julec
 
       - name: Build JuleC
         run: |

--- a/.github/workflows/build_gcc_macos.yml
+++ b/.github/workflows/build_gcc_macos.yml
@@ -1,0 +1,20 @@
+name: Build [GCC] - macOS
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Panquesito7/setup-jule@v1.1.3
+        with:
+          version: dev
+          directory: .
+          add-to-path: true
+
+      - name: Build IR
+        run: |
+          julec --t src/julec
+
+      - name: Build JuleC
+        run: |
+          g++-13 -w --std=c++17 dist/ir.cpp

--- a/.github/workflows/build_gcc_macos.yml
+++ b/.github/workflows/build_gcc_macos.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Build IR
         run: |
-          julec -t src/julec
+          julec --compiler gcc -t src/julec
 
       - name: Build JuleC
         run: |

--- a/.github/workflows/build_gcc_ubuntu.yml
+++ b/.github/workflows/build_gcc_ubuntu.yml
@@ -1,0 +1,16 @@
+name: Build [GCC] - Ubuntu
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Panquesito7/setup-jule@v1.1.3
+        with:
+          version: dev
+          directory: .
+          add-to-path: true
+
+      - name: Build JuleC
+        run: |
+          julec --compiler gcc src/julec

--- a/.github/workflows/tests_clang_macos.yml
+++ b/.github/workflows/tests_clang_macos.yml
@@ -1,13 +1,9 @@
-name: Tests
+name: Tests [Clang] - macOS
 on: [push, pull_request]
 
 jobs:
   build-and-exec:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest]
-
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v4
       - uses: Panquesito7/setup-jule@v1.1.3
@@ -18,64 +14,64 @@ jobs:
 
       - name: Test - Standard Library
         run: |
-          julec -o test tests/std
+          julec --compiler clang -o test tests/std
           ./test
 
       - name: Test - Array OOP
         run: |
-          julec -o test tests/array_oop
+          julec --compiler clang -o test tests/array_oop
           ./test
 
       - name: Assertion
         run: |
-          julec -o test tests/assertion
+          julec --compiler clang -o test tests/assertion
           ./test
 
       - name: Test - Basic Calculator
         run: |
-          julec -o test tests/basic_calculator
+          julec --compiler clang -o test tests/basic_calculator
       
       - name: Test - Concurrency
         run: |
-          julec -o test tests/concurrency
+          julec --compiler clang -o test tests/concurrency
           ./test
 
       - name: Test - Exceptionals
         run: |
-          julec -o test tests/exceptionals
+          julec --compiler clang -o test tests/exceptionals
           ./test
 
       - name: Test - Generics
         run: |
-          julec -o test tests/generics
+          julec --compiler clang -o test tests/generics
           ./test
 
       - name: Test - Levenshtein Distance
         run: |
-          julec -o test tests/levenshtein_distance
+          julec --compiler clang -o test tests/levenshtein_distance
           ./test
 
       - name: Test - Map OOP
         run: |
-          julec -o test tests/map_oop
+          julec --compiler clang -o test tests/map_oop
           ./test
 
       - name: Test - QuickSort
         run: |
-          julec -o test tests/quicksort
+          julec --compiler clang -o test tests/quicksort
           ./test
 
       - name: Test - Sleep
         run: |
-          julec -o test tests/sleep
+          julec --compiler clang -o test tests/sleep
           ./test
 
       - name: Test - Syntax
         run: |
-          julec -o test tests/syntax
+          julec --compiler clang -o test tests/syntax
           ./test
 
       - name: Test - Traits
         run: |
-          julec -o test tests/traits
+          julec --compiler clang -o test tests/traits
           ./test

--- a/.github/workflows/tests_clang_ubuntu.yml
+++ b/.github/workflows/tests_clang_ubuntu.yml
@@ -1,0 +1,77 @@
+name: Tests [Clang] - Ubuntu
+on: [push, pull_request]
+
+jobs:
+  build-and-exec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Panquesito7/setup-jule@v1.1.3
+        with:
+          version: dev
+          directory: .
+          add-to-path: true
+
+      - name: Test - Standard Library
+        run: |
+          julec --compiler clang -o test tests/std
+          ./test
+
+      - name: Test - Array OOP
+        run: |
+          julec --compiler clang -o test tests/array_oop
+          ./test
+
+      - name: Assertion
+        run: |
+          julec --compiler clang -o test tests/assertion
+          ./test
+
+      - name: Test - Basic Calculator
+        run: |
+          julec --compiler clang -o test tests/basic_calculator
+      
+      - name: Test - Concurrency
+        run: |
+          julec --compiler clang -o test tests/concurrency
+          ./test
+
+      - name: Test - Exceptionals
+        run: |
+          julec --compiler clang -o test tests/exceptionals
+          ./test
+
+      - name: Test - Generics
+        run: |
+          julec --compiler clang -o test tests/generics
+          ./test
+
+      - name: Test - Levenshtein Distance
+        run: |
+          julec --compiler clang -o test tests/levenshtein_distance
+          ./test
+
+      - name: Test - Map OOP
+        run: |
+          julec --compiler clang -o test tests/map_oop
+          ./test
+
+      - name: Test - QuickSort
+        run: |
+          julec --compiler clang -o test tests/quicksort
+          ./test
+
+      - name: Test - Sleep
+        run: |
+          julec --compiler clang -o test tests/sleep
+          ./test
+
+      - name: Test - Syntax
+        run: |
+          julec --compiler clang -o test tests/syntax
+          ./test
+
+      - name: Test - Traits
+        run: |
+          julec --compiler clang -o test tests/traits
+          ./test

--- a/.github/workflows/tests_gcc_macos.yml
+++ b/.github/workflows/tests_gcc_macos.yml
@@ -1,0 +1,90 @@
+name: Tests [GCC] - macOS
+on: [push, pull_request]
+
+jobs:
+  build-and-exec:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Panquesito7/setup-jule@v1.1.3
+        with:
+          version: dev
+          directory: .
+          add-to-path: true
+
+      - name: Test - Standard Library
+        run: |
+          julec -t --compiler gcc tests/std
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+          ./test
+
+      - name: Test - Array OOP
+        run: |
+          julec -t --compiler gcc tests/array_oop
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+          ./test
+
+      - name: Assertion
+        run: |
+          julec -t --compiler gcc tests/assertion
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+          ./test
+
+      - name: Test - Basic Calculator
+        run: |
+          julec -t --compiler gcc tests/basic_calculator
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+      
+      - name: Test - Concurrency
+        run: |
+          julec -t --compiler gcc tests/concurrency
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+          ./test
+
+      - name: Test - Exceptionals
+        run: |
+          julec -t --compiler gcc tests/exceptionals
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+          ./test
+
+      - name: Test - Generics
+        run: |
+          julec -t --compiler gcc tests/generics
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+          ./test
+
+      - name: Test - Levenshtein Distance
+        run: |
+          julec -t --compiler gcc tests/levenshtein_distance
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+          ./test
+
+      - name: Test - Map OOP
+        run: |
+          julec -t --compiler gcc tests/map_oop
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+          ./test
+
+      - name: Test - QuickSort
+        run: |
+          julec -t --compiler gcc tests/quicksort
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+          ./test
+
+      - name: Test - Sleep
+        run: |
+          julec -t --compiler gcc tests/sleep
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+          ./test
+
+      - name: Test - Syntax
+        run: |
+          julec -t --compiler gcc tests/syntax
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+          ./test
+
+      - name: Test - Traits
+        run: |
+          julec -t --compiler gcc tests/traits
+          g++-13 -w --std=c++17 dist/ir.cpp -o test
+          ./test

--- a/.github/workflows/tests_gcc_ubuntu.yml
+++ b/.github/workflows/tests_gcc_ubuntu.yml
@@ -1,0 +1,77 @@
+name: Tests [GCC] - Ubuntu
+on: [push, pull_request]
+
+jobs:
+  build-and-exec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Panquesito7/setup-jule@v1.1.3
+        with:
+          version: dev
+          directory: .
+          add-to-path: true
+
+      - name: Test - Standard Library
+        run: |
+          julec --compiler gcc -o test tests/std
+          ./test
+
+      - name: Test - Array OOP
+        run: |
+          julec --compiler gcc -o test tests/array_oop
+          ./test
+
+      - name: Assertion
+        run: |
+          julec --compiler gcc -o test tests/assertion
+          ./test
+
+      - name: Test - Basic Calculator
+        run: |
+          julec --compiler gcc -o test tests/basic_calculator
+      
+      - name: Test - Concurrency
+        run: |
+          julec --compiler gcc -o test tests/concurrency
+          ./test
+
+      - name: Test - Exceptionals
+        run: |
+          julec --compiler gcc -o test tests/exceptionals
+          ./test
+
+      - name: Test - Generics
+        run: |
+          julec --compiler gcc -o test tests/generics
+          ./test
+
+      - name: Test - Levenshtein Distance
+        run: |
+          julec --compiler gcc -o test tests/levenshtein_distance
+          ./test
+
+      - name: Test - Map OOP
+        run: |
+          julec --compiler gcc -o test tests/map_oop
+          ./test
+
+      - name: Test - QuickSort
+        run: |
+          julec --compiler gcc -o test tests/quicksort
+          ./test
+
+      - name: Test - Sleep
+        run: |
+          julec --compiler gcc -o test tests/sleep
+          ./test
+
+      - name: Test - Syntax
+        run: |
+          julec --compiler gcc -o test tests/syntax
+          ./test
+
+      - name: Test - Traits
+        run: |
+          julec --compiler gcc -o test tests/traits
+          ./test


### PR DESCRIPTION
Current CI processes uses only Clang.
This PR adds GCC to existing CI processes.