### PR TITLE
api: use member initializer in the move constructor of `Any`

### DIFF
--- a/api/any.hpp
+++ b/api/any.hpp
@@ -105,11 +105,8 @@ namespace jule
             this->__get_copy(src);
         }
 
-        Any(const jule::Any &&src) noexcept
+        Any(const jule::Any &&src) noexcept : data(src.data), type(src.type)
         {
-            this->data = src.data;
-            this->type = src.type;
-
             // Avoid deallocation.
             src.data = nullptr;
         }


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->
Use member initializer.

By the way: having the following _move constructor_:
```cpp
Any(const jule::Any &&src)
```
does not make much sense. The standard signature should be:
```cpp
Any(jule::Any &&src)
```

I will change it in another PR.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
