### PR TITLE
api: fix cast indicies to `std::size_t` in `Array`

### DIFF
--- a/api/array.hpp
+++ b/api/array.hpp
@@ -26,7 +26,8 @@ namespace jule
     struct Array
     {
     public:
-        mutable Item buffer[N];
+        static_assert(N >= 0);
+        mutable Item buffer[static_cast<std::size_t>(N)];
 
         Array(void) = default;
 
@@ -163,7 +164,7 @@ namespace jule
         // Not includes safety checking.
         constexpr Item &__at(const jule::Int &index) const noexcept
         {
-            return this->buffer[index];
+            return this->buffer[static_cast<std::size_t>(index)];
         }
 
         // Returns element by index.
@@ -226,7 +227,7 @@ namespace jule
             stream << '[';
             for (jule::Int index = 0; index < N;)
             {
-                stream << src.buffer[index++];
+                stream << src[index++];
                 if (index < N)
                     stream << " ";
             }


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->
~In this PR I suggest to use `std::size_t` as the size of the `Array`. The advantage is that it _avoids sign conversions_ and it seems to simplify the logic.~
In order to avoid _sign conversions_ I suggest to cast indices to `std::size_t`.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
~Use `std::size_t` as the size of `Array`.~
Cast indices to `std::size_t` in `Array`.