### PR TITLE
api: prefer `using` when dealing with pointers

### DIFF
--- a/api/array.hpp
+++ b/api/array.hpp
@@ -43,8 +43,8 @@ namespace jule
             std::fill(this->begin(), this->end(), def);
         }
 
-        typedef Item *Iterator;
-        typedef const Item *ConstIterator;
+        using Iterator = Item*;
+        using ConstIterator = const Item*;
 
         constexpr Iterator begin(void) noexcept
         {

--- a/api/slice.hpp
+++ b/api/slice.hpp
@@ -210,8 +210,8 @@ namespace jule
                 *(this->_slice + i) = def;
         }
 
-        typedef Item *Iterator;
-        typedef const Item *ConstIterator;
+        using Iterator = Item*;
+        using ConstIterator = const Item*;
 
         constexpr Iterator begin(void) noexcept
         {

--- a/api/str.hpp
+++ b/api/str.hpp
@@ -61,8 +61,8 @@ namespace jule
             }
         }
 
-        typedef jule::U8 *Iterator;
-        typedef const jule::U8 *ConstIterator;
+        using Iterator = jule::U8*;
+        using ConstIterator = const jule::U8*;
 
         __JULE_INLINE_BEFORE_CPP20 __JULE_CONSTEXPR_SINCE_CPP20 Iterator begin(void) noexcept
         {


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

Somehow the syntax `typedef A *B;` reminds me the [`-->` operator](https://stackoverflow.com/questions/1642028/what-is-the-operator-in-c-c). I would not only change the formatting here but also advocate for `using`.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Prefer `using` when dealing with pointers.