### PR TITLE
api: check if `*this` is `src` in `Array::operator==`

### DIFF
--- a/api/array.hpp
+++ b/api/array.hpp
@@ -142,7 +142,7 @@ namespace jule
 
         constexpr jule::Bool operator==(const jule::Array<Item, N> &src) const
         {
-            if (this->begin() == src.begin())
+            if (*this == src)
                 return true;
 
             jule::Array<Item, N>::ConstIterator it = src.begin();


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

Note that, since `this->begin() == src.begin()` is equivalent to `*this == src`, because `buf` is owned by the `Array` object.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Simplify condition in `Array::operator==`.