### PR TITLE
api: use `std::string::data()` in `jule::Str::begin()`

### DIFF
--- a/api/str.hpp
+++ b/api/str.hpp
@@ -66,12 +66,12 @@ namespace jule
 
         __JULE_INLINE_BEFORE_CPP20 __JULE_CONSTEXPR_SINCE_CPP20 Iterator begin(void) noexcept
         {
-            return static_cast<Iterator>(&this->buffer[0]);
+            return static_cast<Iterator>(this->buffer.data());
         }
 
         __JULE_INLINE_BEFORE_CPP20 __JULE_CONSTEXPR_SINCE_CPP20 ConstIterator begin(void) const noexcept
         {
-            return static_cast<ConstIterator>(&this->buffer[0]);
+            return static_cast<ConstIterator>(this->buffer.data());
         }
 
         __JULE_INLINE_BEFORE_CPP20 __JULE_CONSTEXPR_SINCE_CPP20 Iterator end(void) noexcept


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->
In this PR I suggest to use [`std::string::data()`](https://en.cppreference.com/w/cpp/string/basic_string/data).

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Use `std::string::data()` in `jule::Str::begin()`.