### PR TITLE
api: use `jule::Str::begin()` in `jule::Str::end()`

### DIFF
--- a/api/str.hpp
+++ b/api/str.hpp
@@ -76,12 +76,12 @@ namespace jule
 
         __JULE_INLINE_BEFORE_CPP20 __JULE_CONSTEXPR_SINCE_CPP20 Iterator end(void) noexcept
         {
-            return static_cast<Iterator>(&this->buffer[this->len()]);
+            return this->begin()+this->len();
         }
 
-        inline ConstIterator end(void) const noexcept
+        __JULE_INLINE_BEFORE_CPP20 __JULE_CONSTEXPR_SINCE_CPP20 ConstIterator end(void) const noexcept
         {
-            return static_cast<ConstIterator>(&this->buffer[this->len()]);
+            return this->begin()+this->len();
         }
 
         inline jule::Str slice(


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

The `jule::Str::end()` can be expressed using `jule::Str::begin()`.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Use `jule::Str::begin()` in `jule::Str::end()`.