### PR TITLE
api: use proper return type of `Any::operator=`

### DIFF
--- a/api/any.hpp
+++ b/api/any.hpp
@@ -167,32 +167,35 @@ namespace jule
         }
 
         template <typename T>
-        void operator=(const T &expr) noexcept
+        Any& operator=(const T &expr) noexcept
         {
             jule::Any::Type *type = jule::Any::new_type<T>();
             if (this->type != nullptr && this->type == type)
             {
                 // Same type, not null, avoid allocation, use current.
                 *(T *)this->data = expr;
-                return;
+                return *this;
             }
             this->dealloc();
             this->__assign<T>(expr);
+            return *this;
         }
 
-        void operator=(const jule::Any &src) noexcept
+        Any& operator=(const jule::Any &src) noexcept
         {
             // Assignment to itself.
             if (this->data != nullptr && this->data == src.data)
-                return;
+                return *this;
 
             this->dealloc();
             this->__get_copy(src);
+            return *this;
         }
 
-        inline void operator=(const std::nullptr_t) noexcept
+        inline Any& operator=(const std::nullptr_t) noexcept
         {
             this->dealloc();
+            return *this;
         }
 
         template <typename T>


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description
Overloads of `operator=` for type `T` should return `T&` (cf. [Assignment operator](https://en.cppreference.com/w/cpp/language/operators)).

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Use `Any&` as a return type of `Any::operator=`.