### PR TITLE
api: use proper return type of `Fn::operator=`

### DIFF
--- a/api/fn.hpp
+++ b/api/fn.hpp
@@ -89,19 +89,22 @@ namespace jule
             return this->_addr;
         }
 
-        inline void operator=(std::nullptr_t) noexcept
+        inline Fn<Function>& operator=(std::nullptr_t) noexcept
         {
             this->buffer = nullptr;
+            return *this;
         }
 
-        inline void operator=(const std::function<Function> &function)
+        inline Fn<Function>& operator=(const std::function<Function> &function)
         {
             this->buffer = function;
+            return *this;
         }
 
-        inline void operator=(const Function &function)
+        inline Fn<Function>& operator=(const Function &function)
         {
             this->buffer = function;
+            return *this;
         }
 
         constexpr jule::Bool operator==(const Fn<Function> &fn) const noexcept


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description
Same as #92.

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Use proper return type of `Fn::operator=`.