### PR TITLE
api: use proper return type of `Slice::operator=`

### DIFF
--- a/api/slice.hpp
+++ b/api/slice.hpp
@@ -429,7 +429,7 @@ namespace jule
                 index);
         }
 
-        void operator=(const jule::Slice<Item> &src) noexcept
+        Slice& operator=(const jule::Slice<Item> &src) noexcept
         {
             // Assignment to itself.
             if (this->data.alloc != nullptr && this->data.alloc == src.data.alloc)
@@ -437,16 +437,18 @@ namespace jule
                 this->_len = src._len;
                 this->_cap = src._cap;
                 this->_slice = src._slice;
-                return;
+                return *this;
             }
 
             this->dealloc();
             this->__get_copy(src);
+            return *this;
         }
 
-        inline void operator=(const std::nullptr_t) noexcept
+        inline Slice& operator=(const std::nullptr_t) noexcept
         {
             this->dealloc();
+            return *this;
         }
 
         friend std::ostream &operator<<(std::ostream &stream,


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

Same as #92.

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Use proper return type of `Slice::operator=`.
