### PR TITLE
api: use proper return type of `Ptr::operator=`

### DIFF
--- a/api/ptr.hpp
+++ b/api/ptr.hpp
@@ -272,14 +272,15 @@ namespace jule
             }
         }
 
-        void operator=(const jule::Ptr<T> &src) noexcept
+        Ptr& operator=(const jule::Ptr<T> &src) noexcept
         {
             // Assignment to itself.
             if (this->alloc != nullptr && this->alloc == src.alloc)
-                return;
+                return *this;
 
             this->dealloc();
             this->__get_copy(src);
+            return *this;
         }
 
         inline jule::Bool operator==(const std::nullptr_t &) const noexcept


### PR DESCRIPTION
<!--
    Thank you for contributing to our project, JuleLang!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing guidelines: https://github.com/julelang/jule/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

Same as #92.

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
Use proper return type of `Ptr::operator=`.