### PR TITLE
jule: new trait implementation

### DIFF
--- a/api/trait.hpp
+++ b/api/trait.hpp
@@ -6,7 +6,6 @@
 #define __JULE_TRAIT_HPP
 
 #include <string>
-#include <typeinfo>
 #include <ostream>
 #include <cstring>
 
@@ -17,75 +16,55 @@
 
 namespace jule
 {
-    template <typename T>
-    struct TraitDynamicType
-    {
-    public:
-        static void dealloc(jule::Ptr<jule::Uintptr> &alloc) noexcept
-        {
-            alloc.__as<T>().dealloc();
-        }
-    };
-
-    struct TraitType
-    {
-    public:
-        void (*dealloc)(jule::Ptr<jule::Uintptr> &alloc);
-    };
-
-    template <typename T>
-    static jule::TraitType *new_trait_type(void) noexcept
-    {
-        using type = typename std::decay<jule::TraitDynamicType<T>>::type;
-        static jule::TraitType table = {
-            .dealloc = type::dealloc,
-        };
-        return &table;
-    }
-
-    template <typename Mask>
+    // Trait data container for Jule's traits.
+    // The `type` field points to `jule::Trait::Type` for deallocation,
+    // but it actually points to static data for trait's runtime data type.
+    // So, compiler may cast it to actual data type to use it. Therefore,
+    // the first field of the static data is should be always deallocation function pointer.
     struct Trait
     {
     public:
+        struct Type
+        {
+        public:
+            void (*dealloc)(jule::Ptr<jule::Uintptr> &);
+        };
+
         mutable jule::Ptr<jule::Uintptr> data;
-        mutable jule::TraitType *type = nullptr;
-        mutable jule::Int type_offset = -1;
+        mutable jule::Trait::Type *type = nullptr;
         mutable jule::Bool ptr = false;
 
         Trait(void) = default;
         Trait(std::nullptr_t) : Trait() {}
 
-        Trait(const jule::Trait<Mask> &trait)
+        Trait(const jule::Trait &trait)
         {
             this->__get_copy(trait);
         }
 
-        Trait(jule::Trait<Mask> &&trait)
+        Trait(jule::Trait &&trait)
         {
             this->__get_copy(trait);
         }
 
-        void __get_copy(const jule::Trait<Mask> &trait)
+        void __get_copy(const jule::Trait &trait)
         {
             this->data = trait.data;
-            this->type_offset = trait.type_offset;
             this->type = trait.type;
             this->ptr = trait.ptr;
         }
 
-        void __get_copy(jule::Trait<Mask> &&trait)
+        void __get_copy(jule::Trait &&trait)
         {
             this->data = std::move(trait.data);
-            this->type_offset = trait.type_offset;
             this->type = trait.type;
             this->ptr = trait.ptr;
         }
 
         template <typename T>
-        Trait(const T &data, const jule::Int &type_offset) noexcept
+        Trait(const T &data, jule::Trait::Type *type) noexcept
         {
-            this->type_offset = type_offset;
-            this->type = jule::new_trait_type<T>();
+            this->type = type;
             this->ptr = false;
             T *alloc = new (std::nothrow) T;
             if (!alloc)
@@ -100,10 +79,9 @@ namespace jule
         }
 
         template <typename T>
-        Trait(const jule::Ptr<T> &ref, const jule::Int &type_offset) noexcept
+        Trait(const jule::Ptr<T> &ref, jule::Trait::Type *type) noexcept
         {
-            this->type_offset = type_offset;
-            this->type = jule::new_trait_type<T>();
+            this->type = type;
             this->ptr = true;
             this->data = ref.template as<jule::Uintptr>();
         }
@@ -117,7 +95,6 @@ namespace jule
         {
             this->data.ref = nullptr;
             this->data.alloc = nullptr;
-            this->type_offset = -1;
             this->ptr = false;
         }
 
@@ -151,265 +128,12 @@ namespace jule
             }
         }
 
-        inline jule::Bool type_is(const jule::Bool &ptr, const jule::Int &type_offset) const noexcept
-        {
-            return this->ptr == ptr && this->type_offset == type_offset;
-        }
-
-        template <typename T>
-        inline T *safe_ptr(
-#ifndef __JULE_ENABLE__PRODUCTION
-            const char *file
-#else
-            void
-#endif
-        )
-        {
-#ifndef __JULE_DISABLE__SAFETY
-            this->must_ok(
-#ifndef __JULE_ENABLE__PRODUCTION
-                file
-#endif
-            );
-#endif
-            return reinterpret_cast<T *>(this->data.alloc);
-        }
-
-        template <typename T>
-        inline T cast(
-#ifndef __JULE_ENABLE__PRODUCTION
-            const char *file,
-#endif
-            const jule::Int &type_offset) noexcept
-        {
-#ifndef __JULE_DISABLE__SAFETY
-            this->must_ok(
-#ifndef __JULE_ENABLE__PRODUCTION
-                file
-#endif
-            );
-            if (!this->type_is(false, type_offset))
-            {
-#ifndef __JULE_ENABLE__PRODUCTION
-                std::string error = __JULE_ERROR__INCOMPATIBLE_TYPE "\nruntime: trait casted to incompatible type\nfile: ";
-                error += file;
-                jule::panic(error);
-#else
-                jule::panic(__JULE_ERROR__INCOMPATIBLE_TYPE "\nruntime: trait casted to incompatible type");
-#endif
-            }
-#endif
-            return *static_cast<T *>(this->data.alloc);
-        }
-
-        template <typename T>
-        jule::Ptr<T> cast_ptr(
-#ifndef __JULE_ENABLE__PRODUCTION
-            const char *file,
-#endif
-            const jule::Int &type_offset) noexcept
-        {
-#ifndef __JULE_DISABLE__SAFETY
-            this->must_ok(
-#ifndef __JULE_ENABLE__PRODUCTION
-                file
-#endif
-            );
-            if (!this->type_is(true, type_offset))
-            {
-#ifndef __JULE_ENABLE__PRODUCTION
-                std::string error = __JULE_ERROR__INCOMPATIBLE_TYPE "\nruntime: trait casted to incompatible type\nfile: ";
-                error += file;
-                jule::panic(error);
-#else
-                jule::panic(__JULE_ERROR__INCOMPATIBLE_TYPE "\nruntime: trait casted to incompatible type");
-#endif
-            }
-#endif
-            return this->data.template as<T>();
-        }
-
-        template <typename NewMask>
-        inline jule::Trait<NewMask> map(jule::Int (*offsetMapper)(const jule::Int)) noexcept
-        {
-            jule::Trait<NewMask> newTrait;
-            newTrait.type = this->type;
-            newTrait.ptr = this->ptr;
-            newTrait.data = this->data;
-            newTrait.type_offset = offsetMapper(this->type_offset);
-            return newTrait;
-        }
-
-        inline jule::Trait<Mask> &operator=(const std::nullptr_t) noexcept
-        {
-            this->dealloc();
-            return *this;
-        }
-
-        inline jule::Trait<Mask> &operator=(const jule::Trait<Mask> &src) noexcept
-        {
-            this->dealloc();
-            this->__get_copy(src);
-            return *this;
-        }
-
-        inline jule::Trait<Mask> &operator=(jule::Trait<Mask> &&src) noexcept
-        {
-            this->dealloc();
-            this->__get_copy(src);
-            return *this;
-        }
-
-        constexpr jule::Bool operator==(const jule::Trait<Mask> &src) const noexcept
-        {
-            return this->data.alloc == src.data.alloc;
-        }
-
-        constexpr jule::Bool operator!=(const jule::Trait<Mask> &src) const noexcept
-        {
-            return !this->operator==(src);
-        }
-
-        constexpr jule::Bool operator==(std::nullptr_t) const noexcept
-        {
-            return this->data.alloc == nullptr;
-        }
-
-        constexpr jule::Bool operator!=(std::nullptr_t) const noexcept
-        {
-            return !this->operator==(nullptr);
-        }
-
-        friend inline std::ostream &operator<<(std::ostream &stream,
-                                               const jule::Trait<Mask> &src) noexcept
-        {
-            if (src == nullptr)
-                return stream << "<nil>";
-            return stream << (void *)src.data.alloc;
-        }
-    };
-} // namespace jule
-
-namespace jule
-{
-    // Trait data container for Jule's traits.
-    // The `type` field points to `jule::Trait::Type` for deallocation,
-    // but it actually points to static data for trait's runtime data type.
-    // So, compiler may cast it to actual data type to use it. Therefore,
-    // the first field of the static data is should be always deallocation function pointer.
-    struct Trait2
-    {
-    public:
-        struct Type
-        {
-        public:
-            void (*dealloc)(jule::Ptr<jule::Uintptr> &);
-        };
-
-        mutable jule::Ptr<jule::Uintptr> data;
-        mutable jule::Trait2::Type *type = nullptr;
-        mutable jule::Bool ptr = false;
-
-        Trait2(void) = default;
-        Trait2(std::nullptr_t) : Trait2() {}
-
-        Trait2(const jule::Trait2 &trait)
-        {
-            this->__get_copy(trait);
-        }
-
-        Trait2(jule::Trait2 &&trait)
-        {
-            this->__get_copy(trait);
-        }
-
-        void __get_copy(const jule::Trait2 &trait)
-        {
-            this->data = trait.data;
-            this->type = trait.type;
-            this->ptr = trait.ptr;
-        }
-
-        void __get_copy(jule::Trait2 &&trait)
-        {
-            this->data = std::move(trait.data);
-            this->type = trait.type;
-            this->ptr = trait.ptr;
-        }
-
-        template <typename T>
-        Trait2(const T &data, jule::Trait2::Type *type) noexcept
-        {
-            this->type = type;
-            this->ptr = false;
-            T *alloc = new (std::nothrow) T;
-            if (!alloc)
-                jule::panic(__JULE_ERROR__MEMORY_ALLOCATION_FAILED "\nfile: /api/trait.hpp");
-
-            *alloc = data;
-#ifdef __JULE_DISABLE__REFERENCE_COUNTING
-            this->data = jule::Ptr<jule::Uintptr>::make(reinterpret_cast<jule::Uintptr *>(alloc), nullptr);
-#else
-            this->data = jule::Ptr<jule::Uintptr>::make(reinterpret_cast<jule::Uintptr *>(alloc));
-#endif
-        }
-
-        template <typename T>
-        Trait2(const jule::Ptr<T> &ref, jule::Trait2::Type *type) noexcept
-        {
-            this->type = type;
-            this->ptr = true;
-            this->data = ref.template as<jule::Uintptr>();
-        }
-
-        ~Trait2(void) noexcept
-        {
-            this->dealloc();
-        }
-
-        void __free(void) const noexcept
-        {
-            this->data.ref = nullptr;
-            this->data.alloc = nullptr;
-            this->ptr = false;
-        }
-
-        void dealloc(void) const noexcept
-        {
-            if (this->type)
-            {
-                this->type->dealloc(this->data);
-                this->type = nullptr;
-            }
-            this->__free();
-        }
-
-        inline void must_ok(
-#ifndef __JULE_ENABLE__PRODUCTION
-            const char *file
-#else
-            void
-#endif
-        ) const noexcept
-        {
-            if (this->operator==(nullptr))
-            {
-#ifndef __JULE_ENABLE__PRODUCTION
-                std::string error = __JULE_ERROR__INVALID_MEMORY "\nfile: ";
-                error += file;
-                jule::panic(error);
-#else
-                jule::panic(__JULE_ERROR__INVALID_MEMORY "\nfile: /api/trait.hpp");
-#endif
-            }
-        }
-
-        inline jule::Bool type_is(const jule::Bool ptr, const jule::Trait2::Type *type) const noexcept
+        inline jule::Bool type_is(const jule::Bool ptr, const jule::Trait::Type *type) const noexcept
         {
             return this->ptr == ptr && this->type == type;
         }
 
-        inline jule::Trait2::Type *safe_type(
+        inline jule::Trait::Type *safe_type(
 #ifndef __JULE_ENABLE__PRODUCTION
             const char *file
 #else
@@ -432,7 +156,7 @@ namespace jule
 #ifndef __JULE_ENABLE__PRODUCTION
             const char *file,
 #endif
-            const jule::Trait2::Type *type) noexcept
+            const jule::Trait::Type *type) noexcept
         {
 #ifndef __JULE_DISABLE__SAFETY
             this->must_ok(
@@ -459,7 +183,7 @@ namespace jule
 #ifndef __JULE_ENABLE__PRODUCTION
             const char *file,
 #endif
-            const jule::Trait2::Type *type) noexcept
+            const jule::Trait::Type *type) noexcept
         {
 #ifndef __JULE_DISABLE__SAFETY
             this->must_ok(
@@ -481,41 +205,41 @@ namespace jule
             return this->data.template as<T>();
         }
 
-        inline jule::Trait2 mask(void *(*typeMapper)(const void *)) noexcept
+        inline jule::Trait mask(void *(*typeMapper)(const void *)) noexcept
         {
-            jule::Trait2 newTrait;
-            newTrait.type = (jule::Trait2::Type *)typeMapper((void *)this->type);
+            jule::Trait newTrait;
+            newTrait.type = (jule::Trait::Type *)typeMapper((void *)this->type);
             newTrait.ptr = this->ptr;
             newTrait.data = this->data;
             return newTrait;
         }
 
-        inline jule::Trait2 &operator=(const std::nullptr_t) noexcept
+        inline jule::Trait &operator=(const std::nullptr_t) noexcept
         {
             this->dealloc();
             return *this;
         }
 
-        inline jule::Trait2 &operator=(const jule::Trait2 &src) noexcept
-        {
-            this->dealloc();
-            this->__get_copy(src);
-            return *this;
-        }
-
-        inline jule::Trait2 &operator=(jule::Trait2 &&src) noexcept
+        inline jule::Trait &operator=(const jule::Trait &src) noexcept
         {
             this->dealloc();
             this->__get_copy(src);
             return *this;
         }
 
-        constexpr jule::Bool operator==(const jule::Trait2 &src) const noexcept
+        inline jule::Trait &operator=(jule::Trait &&src) noexcept
+        {
+            this->dealloc();
+            this->__get_copy(src);
+            return *this;
+        }
+
+        constexpr jule::Bool operator==(const jule::Trait &src) const noexcept
         {
             return this->data.alloc == src.data.alloc;
         }
 
-        constexpr jule::Bool operator!=(const jule::Trait2 &src) const noexcept
+        constexpr jule::Bool operator!=(const jule::Trait &src) const noexcept
         {
             return !this->operator==(src);
         }
@@ -531,7 +255,7 @@ namespace jule
         }
 
         friend inline std::ostream &operator<<(std::ostream &stream,
-                                               const jule::Trait2 &src) noexcept
+                                               const jule::Trait &src) noexcept
         {
             if (src == nullptr)
                 return stream << "<nil>";

--- a/src/julec/obj/cxx/expr.jule
+++ b/src/julec/obj/cxx/expr.jule
@@ -382,9 +382,7 @@ impl exprCoder {
 
     fn castTraitFromTrait(mut &self, mut &m: &CastingExprModel, mut t1: &Trait, mut t2: &Trait) {
         self.possibleRefExpr(m.Expr.Model)
-        self.oc.write(".mask<")
-        identCoder.traitDecl(self.oc.Buf, t1)
-        self.oc.write(">(")
+        self.oc.write(".map(")
         self.oc.pushAndWriteMaskMapper(t1, t2)
         self.oc.write(")")
     }
@@ -475,6 +473,9 @@ impl exprCoder {
                 self.oc.locInfo(m.Token)
                 self.oc.write("\", ")
             }
+            self.oc.write("(" + typeCoder.Trait + "::Type*)&")
+            identCoder.traitDecl(self.oc.Buf, m.ExprKind.Trait())
+            self.oc.write("_mptr_data")
             self.oc.write(conv::Itoa(self.oc.findTypeOffset(m.ExprKind.Trait(), m.Kind)))
             self.oc.write(")")
             ret
@@ -482,7 +483,9 @@ impl exprCoder {
             self.oc.tc.kind(self.oc.Buf, m.Kind)
             self.oc.write("(")
             self.possibleRefExpr(m.Expr.Model)
-            self.oc.write(", ")
+            self.oc.write(", (" + typeCoder.Trait + "::Type*)&")
+            identCoder.traitDecl(self.oc.Buf, m.Kind.Trait())
+            self.oc.write("_mptr_data")
             self.oc.write(conv::Itoa(self.oc.findTypeOffset(m.Kind.Trait(), m.ExprKind)))
             self.oc.write(")")
             ret
@@ -652,7 +655,6 @@ impl exprCoder {
                 self.oc.write(", ")
             }
         }
-        mut locinfo := false
         if !m.Func.IsBuiltin() && len(m.Func.Decl.Params) > 0 && m.Func.Decl.Params[0].IsSelf() {
             match type m.Expr {
             | &StructSubIdentExprModel:
@@ -701,20 +703,13 @@ impl exprCoder {
                 }
             | &TraitSubIdentExprModel:
                 self.possibleRefExpr((&TraitSubIdentExprModel)(m.Expr).Expr)
-                if !env::Production {
-                    locinfo = true
-                }
+                self.oc.write(".data")
                 if len(m.Args) > 0 {
                     self.oc.write(", ")
                 }
             }
         }
         self.args(m)
-        if locinfo {
-            self.oc.write(", \"")
-            self.oc.locInfo(m.Token)
-            self.oc.write("\"")
-        }
         self.oc.write(")")
 
         if wrapped {
@@ -1005,11 +1000,18 @@ impl exprCoder {
     }
 
     fn traitSub(mut &self, mut m: &TraitSubIdentExprModel) {
+        self.oc.write("((")
         identCoder.traitDecl(self.oc.Buf, m.Trt)
-        self.oc.write("_mptr_data")
-        self.oc.write("[(")
+        self.oc.write("MptrData")
+        self.oc.write("*)")
         self.possibleRefExpr(m.Expr)
-        self.oc.write(").type_offset].")
+        self.oc.write(".safe_type(")
+        if !env::Production {
+            self.oc.write("\"")
+            self.oc.locInfo(m.Token)
+            self.oc.write("\"")
+        }
+        self.oc.write("))->")
         identCoder.func(self.oc.Buf, m.Method)
     }
 

--- a/src/julec/obj/cxx/object.jule
+++ b/src/julec/obj/cxx/object.jule
@@ -49,6 +49,7 @@ const ctxParamIdent = "__f_ctx"
 const anonFnCtxSuffix = "_ctx"                              // Anon fn identifier suffix for ctx struct identifier.
 const anonFnCtxHandlerSuffix = anonFnCtxSuffix + "_handler" // Anon fn identifier suffix for ctx allocation handler.
 const anyTypeIdent = "__jule_any_type"
+const deallocatedTypeIdent = "__jule_type_deallocator"
 const indentKind = '\t'
 
 struct SerializationInfo {
@@ -80,11 +81,13 @@ struct ObjectCoder {
     resultDecls: StrBuilder // Struct wrappers for multi-ret function types.
     anyObj:      StrBuilder // Type handlers and others for the <any> type.
     anonObj:     StrBuilder // Anonymous functions.
+    deallocObj:  StrBuilder // Deallocation function for [self.deallocated] types.
 
-    ir:   &IR
-    info: SerializationInfo
-    tmap: []&traitHash
-    anons: []&anonHash
+    ir:          &IR
+    info:        SerializationInfo
+    tmap:        []&traitHash
+    anons:       []&anonHash
+    deallocated: []&TypeKind // GC deallocated types for dynamic programming.
 
     // Current indentation.
     indentBuffer: []byte
@@ -145,6 +148,22 @@ impl ObjectCoder {
         ret -1
     }
 
+    fn pushDealloc(mut &self, mut t: &TypeKind): int {
+        for i, dt in self.deallocated {
+            if dt.Equal(t) {
+                ret i
+            }
+        }
+        i := len(self.deallocated)
+        self.deallocated = append(self.deallocated, t)
+        self.deallocObj.WriteStr("void " + deallocatedTypeIdent)
+        self.deallocObj.WriteStr(conv::Itoa(i))
+        self.deallocObj.WriteStr("(jule::Ptr<jule::Uintptr> &alloc) noexcept { alloc.__as<")
+        self.tc.kind(self.deallocObj, t)
+        self.deallocObj.WriteStr(">().dealloc(); }\n")
+        ret i
+    }
+
     fn pushAnonFn(mut &self, mut &m: &AnonFnExprModel): (ident: str) {
         closure := isClosure(m)
         if closure { // Closure?
@@ -200,20 +219,16 @@ impl ObjectCoder {
             mut elemKind := StrBuilder.New(40)
             self.tc.kind(elemKind, t.Sptr().Elem)
 
-            // dealloc function.
-            self.anyObj.WriteStr("void " + anyTypeIdent)
-            self.anyObj.WriteStr(si)
-            self.anyObj.WriteStr("_dealloc(jule::Ptr<jule::Uintptr> &alloc) noexcept { alloc.__as<")
-            self.anyObj.Write(unsafe { elemKind.Buf() })
-            self.anyObj.WriteStr(">().dealloc(); }\n")
+            // Deallocator function.
+            di := self.pushDealloc(t.Sptr().Elem)
 
             // Type structure.
             self.anyObj.WriteStr("struct " + typeCoder.Any + "::Type ")
             self.anyObj.WriteStr(anyTypeIdent)
             self.anyObj.WriteStr(si)
-            self.anyObj.WriteStr("{.dealloc=" + anyTypeIdent)
-            self.anyObj.WriteStr(si)
-            self.anyObj.WriteStr("_dealloc, .eq=jule::ptr_equal, .to_str=jule::ptr_to_str};\n")
+            self.anyObj.WriteStr("{.dealloc=" + deallocatedTypeIdent)
+            self.anyObj.WriteStr(conv::Itoa(di))
+            self.anyObj.WriteStr(", .eq=jule::ptr_equal, .to_str=jule::ptr_to_str};\n")
 
             // comparison function.
             self.anyObj.WriteStr(typeCoder.Bool + " " + anyTypeIdent)
@@ -232,12 +247,8 @@ impl ObjectCoder {
                 outln(t.Str())
             }
 
-            // dealloc function.
-            self.anyObj.WriteStr("void " + anyTypeIdent)
-            self.anyObj.WriteStr(si)
-            self.anyObj.WriteStr("_dealloc(jule::Ptr<jule::Uintptr> &alloc) noexcept { alloc.__as<")
-            self.anyObj.Write(kind)
-            self.anyObj.WriteStr(">().dealloc(); }\n")
+            // Deallocator function.
+            di := self.pushDealloc(t)
 
             if comparable {
                 // eq function.
@@ -267,9 +278,9 @@ impl ObjectCoder {
             self.anyObj.WriteStr("struct " + typeCoder.Any + "::Type ")
             self.anyObj.WriteStr(anyTypeIdent)
             self.anyObj.WriteStr(si)
-            self.anyObj.WriteStr("{.dealloc=" + anyTypeIdent)
-            self.anyObj.WriteStr(si)
-            self.anyObj.WriteStr("_dealloc, ")
+            self.anyObj.WriteStr("{.dealloc=" + deallocatedTypeIdent)
+            self.anyObj.WriteStr(conv::Itoa(di))
+            self.anyObj.WriteStr(", ")
             if comparable {
                 self.anyObj.WriteStr(".eq=" + anyTypeIdent)
                 self.anyObj.WriteStr(si)
@@ -1422,6 +1433,14 @@ impl ObjectCoder {
 
         self.anonHashes()
 
+        if self.deallocObj.Len() > 0 {
+            mut head := make([]byte, 0, self.Buf.Len() + self.deallocObj.Len())
+            head = append(head, unsafe { self.Buf.Buf() }[:self.declPos]...)
+            head = append(head, unsafe { self.deallocObj.Buf() }...)
+            head = append(head, unsafe { self.Buf.Buf() }[self.declPos:]...)
+            unsafe { self.Buf.SetBuf(head) }
+            self.declPos += self.deallocObj.Len()
+        }
         if self.anyObj.Len() > 0 {
             mut head := make([]byte, 0, self.Buf.Len() + self.anyObj.Len())
             head = append(head, unsafe { self.Buf.Buf() }[:self.declPos]...)

--- a/src/julec/obj/cxx/object.jule
+++ b/src/julec/obj/cxx/object.jule
@@ -1409,6 +1409,16 @@ impl ObjectCoder {
 }`)
     }
 
+    fn insertBuf(mut &self, mut &buf: StrBuilder, pos: int) {
+        if buf.Len() > 0 {
+            mut head := make([]byte, 0, self.Buf.Len() + buf.Len())
+            head = append(head, unsafe { self.Buf.Buf() }[:pos]...)
+            head = append(head, unsafe { buf.Buf() }...)
+            head = append(head, unsafe { self.Buf.Buf() }[pos:]...)
+            unsafe { self.Buf.SetBuf(head) }
+        }
+    }
+
     fn serializeHead(mut &self) {
         self.prepareStructures()
         self.buildTraitMap()
@@ -1416,14 +1426,8 @@ impl ObjectCoder {
         self.write("\n")
         self.decls()
 
-        if self.resultDecls.Len() > 0 {
-            mut head := make([]byte, 0, self.Buf.Len() + self.resultDecls.Len())
-            head = append(head, unsafe { self.Buf.Buf() }[:self.headPos]...)
-            head = append(head, unsafe { self.resultDecls.Buf() }...)
-            self.declPos += self.resultDecls.Len()
-            head = append(head, unsafe { self.Buf.Buf() }[self.headPos:]...)
-            unsafe { self.Buf.SetBuf(head) }
-        }
+        self.insertBuf(self.resultDecls, self.headPos)
+        self.declPos += self.resultDecls.Len()
 
         self.write("\n")
         self.structures()
@@ -1433,29 +1437,14 @@ impl ObjectCoder {
 
         self.anonHashes()
 
-        if self.deallocObj.Len() > 0 {
-            mut head := make([]byte, 0, self.Buf.Len() + self.deallocObj.Len())
-            head = append(head, unsafe { self.Buf.Buf() }[:self.declPos]...)
-            head = append(head, unsafe { self.deallocObj.Buf() }...)
-            head = append(head, unsafe { self.Buf.Buf() }[self.declPos:]...)
-            unsafe { self.Buf.SetBuf(head) }
-            self.declPos += self.deallocObj.Len()
-        }
-        if self.anyObj.Len() > 0 {
-            mut head := make([]byte, 0, self.Buf.Len() + self.anyObj.Len())
-            head = append(head, unsafe { self.Buf.Buf() }[:self.declPos]...)
-            head = append(head, unsafe { self.anyObj.Buf() }...)
-            head = append(head, unsafe { self.Buf.Buf() }[self.declPos:]...)
-            unsafe { self.Buf.SetBuf(head) }
-            self.declPos += self.anyObj.Len()
-        }
-        if self.anonObj.Len() > 0 {
-            mut head := make([]byte, 0, self.Buf.Len() + self.anonObj.Len())
-            head = append(head, unsafe { self.Buf.Buf() }[:self.declPos]...)
-            head = append(head, unsafe { self.anonObj.Buf() }...)
-            head = append(head, unsafe { self.Buf.Buf() }[self.declPos:]...)
-            unsafe { self.Buf.SetBuf(head) }
-        }
+        self.insertBuf(self.deallocObj, self.declPos)
+        self.declPos += self.deallocObj.Len()
+
+        self.insertBuf(self.anyObj, self.declPos)
+        self.declPos += self.anyObj.Len()
+
+        self.insertBuf(self.anonObj, self.declPos)
+        self.declPos += self.anonObj.Len()
     }
 
     fn Serialize(mut &self) {

--- a/src/julec/obj/cxx/object.jule
+++ b/src/julec/obj/cxx/object.jule
@@ -920,7 +920,7 @@ impl ObjectCoder {
         })
     }
 
-    fn traitDataTypeMethods(mut &self, mut &owner: &Trait, mut &t: &Trait) {
+    fn traitDataTypeMethods(mut &self, mut &t: &Trait) {
         for (_, mut m) in t.Methods {
             mut ins := m.Instances[0]
             mut p := ins.Params[0]
@@ -952,7 +952,7 @@ impl ObjectCoder {
                     self.addIndent()
                     self.indent()
                     self.write("void (*dealloc)(" + typeCoder.Ptr + "<" + typeCoder.Uintptr + ">&);\n")
-                    self.traitDataTypeMethods(t, t)
+                    self.traitDataTypeMethods(t)
                     self.doneIndent()
                     self.indent()
                     self.write("};\n\n")

--- a/src/julec/obj/cxx/object.jule
+++ b/src/julec/obj/cxx/object.jule
@@ -38,6 +38,7 @@ use std::jule::sema::{
     Operators,
     AnonFnExprModel,
 }
+use types for std::jule::types
 use path for std::fs::path
 use strings for std::strings::{StrBuilder}
 use std::time::{Time}
@@ -51,6 +52,17 @@ const anonFnCtxHandlerSuffix = anonFnCtxSuffix + "_handler" // Anon fn identifie
 const anyTypeIdent = "__jule_any_type"
 const deallocatedTypeIdent = "__jule_type_deallocator"
 const indentKind = '\t'
+
+// General pointer type for GC pointers.
+static mut generalGCPtr = &TypeKind{
+    Kind: &Sptr{
+        Elem: &TypeKind{
+            Kind: &Prim{
+                Kind: types::TypeKind.Uintptr,
+            },
+        },
+    },
+}
 
 struct SerializationInfo {
     Compiler:        str
@@ -102,6 +114,7 @@ struct ObjectCoder {
 
     headPos: int
     declPos: int
+    wrapPos: int
 }
 
 impl ObjectCoder {
@@ -243,9 +256,6 @@ impl ObjectCoder {
             mut kindB := StrBuilder.New(40)
             self.tc.kind(kindB, t)
             kind := unsafe { kindB.Buf() }
-            if unsafe::BytesStr(kind) == "[<unimplemented_type_kind>]" {
-                outln(t.Str())
-            }
 
             // Deallocator function.
             di := self.pushDealloc(t)
@@ -385,34 +395,36 @@ impl ObjectCoder {
         self.traitCastMap = append(self.traitCastMap, traitCast{t1: t1, t2: t2})
 
         // Not exist, push.
-        //
-        // TODO:
-        //  As partially confirmed by the experiments, the same mapping conditions
-        //  apply for two traits that casting into each other. It was decided that
-        //  additional investigation was needed to conclusively confirm this.
-        const offset = "offset"
-        self.anyObj.WriteStr(typeCoder.Int)
-        self.anyObj.WriteByte(' ')
+        const data = "data"
+        self.anyObj.WriteStr("void *")
         self.anyObj.Write(unsafe { ident.Buf() })
-        self.anyObj.WriteStr("(const " + typeCoder.Int + " " + offset + ") noexcept { ")
+        self.anyObj.WriteStr("(const void *" + data + ") noexcept { ")
+
+        mut t1Ident := StrBuilder.New(1 << 4)
+        mut t2Ident := StrBuilder.New(1 << 4)
+        identCoder.traitDecl(t1Ident, t1)
+        identCoder.traitDecl(t2Ident, t2)
+
         for (_, mut s1) in t1.Implemented {
             for _, s2 in t2.Implemented {
                 if s1 == s2 {
                     for (_, mut s1i) in s1.Instances {
                         i1 := self.findTypeOffsetS(t1, s1i)
                         i2 := self.findTypeOffsetS(t2, s1i)
-                        self.anyObj.WriteStr("if (offset == ")
+                        self.anyObj.WriteStr("if (data == &")
+                        self.anyObj.Write(unsafe { t2Ident.Buf() })
+                        self.anyObj.WriteStr("_mptr_data")
                         self.anyObj.WriteStr(conv::Itoa(i2))
-                        self.anyObj.WriteStr(") return ")
+                        self.anyObj.WriteStr(") return &")
+                        self.anyObj.Write(unsafe { t1Ident.Buf() })
+                        self.anyObj.WriteStr("_mptr_data")
                         self.anyObj.WriteStr(conv::Itoa(i1))
                         self.anyObj.WriteStr("; ")
                     }
                 }
             }
         }
-        self.anyObj.WriteStr(" return ")
-        self.anyObj.WriteStr(conv::Itoa(emptyTraitOffset))
-        self.anyObj.WriteStr("; }\n")
+        self.anyObj.WriteStr(" jule::panic(\"trait casting failed because of an implementation mistake, this is a JuleC bug\"); return nullptr; }\n")
     }
 
     // Writes location information of token as cstr bytes.
@@ -574,22 +586,6 @@ impl ObjectCoder {
                     // Push all methods to t from t's inheritances.
                     // Because they will be used for trait data generation.
                     pushMethodsFromInherits(t, t)
-                }
-            })
-        })
-    }
-
-    fn traitDecls(mut &self) {
-        self.iterPackages(fn(mut &pkg: &Package) {
-            iterFiles(pkg, fn(mut &file: &SymbolTable) {
-                for (_, mut t) in file.Traits {
-                    if t.Token == nil {
-                        ret
-                    }
-                    self.indent()
-                    self.write("struct ")
-                    identCoder.traitDecl(self.Buf, t)
-                    self.write("{};\n")
                 }
             })
         })
@@ -902,11 +898,11 @@ impl ObjectCoder {
         }
     }
 
-    fn funcDeclTrait(mut &self, mut &t: &Trait, mut &f: &Fn, ptr: bool) {
+    fn funcDeclTrait(mut &self, mut &f: &Fn) {
         for (_, mut c) in f.Instances {
             mut k := c.Params[0].Kind
-            c.Params[0].Kind = &TypeKind{Kind: t}
-            self.funcDeclIns(c, ptr)
+            c.Params[0].Kind = generalGCPtr
+            self.funcDeclIns(c, true)
             c.Params[0].Kind = k
         }
     }
@@ -928,34 +924,14 @@ impl ObjectCoder {
         for (_, mut m) in t.Methods {
             mut ins := m.Instances[0]
             mut p := ins.Params[0]
-            p.Kind = &TypeKind{
-                Kind: t,
-            }
+            p.Kind = &TypeKind{Kind: t}
             for (i, mut ip) in ins.Params[1:] {
                 if IsAnonIdent(ip.Decl.Ident) {
                     ip.Decl.Ident = "_" + conv::Itoa(i)
                 }
             }
-            if !env::Production {
-                mut lp := ins.Params[len(ins.Params)-1]
-                match type lp.Kind.Kind {
-                | &customType:
-                    break
-                |:
-                    ins.Params = append(ins.Params, &ParamIns{
-                        Decl: &Param{
-                            Ident: "__file",
-                        },
-                        Kind: &TypeKind{
-                            Kind: &customType{
-                                kind: "const char*",
-                            },
-                        },
-                    })
-                }
-            }
             self.pushResult(m)
-            self.funcDeclTrait(owner, m, true)
+            self.funcDeclTrait(m)
         }
     }
 
@@ -974,6 +950,8 @@ impl ObjectCoder {
                     self.write("MptrData")
                     self.write(" {\n")
                     self.addIndent()
+                    self.indent()
+                    self.write("void (*dealloc)(" + typeCoder.Ptr + "<" + typeCoder.Uintptr + ">&);\n")
                     self.traitDataTypeMethods(t, t)
                     self.doneIndent()
                     self.indent()
@@ -1106,7 +1084,7 @@ impl ObjectCoder {
             f.Ident = s.Str()
 
             mut k := ins.Params[0].Kind
-            ins.Params[0].Kind = &TypeKind{Kind: hash.t}
+            ins.Params[0].Kind = generalGCPtr
             self.funcIns(ins)
             ins.Params[0].Kind = k
         }
@@ -1114,16 +1092,11 @@ impl ObjectCoder {
     }
 
     fn traitWrapper(mut &self, mut &m: &Fn, mut &hash: &traitHash) {
-        self.funcTrait(hash, m)
-
-        if hash.s == nil {
-            if env::Production {
-                self.write(" { jule::panic(__JULE_ERROR__INVALID_MEMORY); }\n")
-            } else {
-                self.write(" { jule::panic(" + typeCoder.Str + "(__JULE_ERROR__INVALID_MEMORY \"\\nlocation: \") + " + typeCoder.Str + "(_00___file)); }\n")
-            }
+        if len(hash.t.Implemented) == 0 {
             ret
         }
+
+        self.funcTrait(hash, m)
 
         ptr := !m.Params[0].IsRef()
 
@@ -1140,18 +1113,15 @@ impl ObjectCoder {
         }
         identCoder.func(self.Buf, sm)
         self.write("(")
+        self.write("_self_.as<")
         if ptr {
-            self.write("_self_.safe_ptr<")
             self.tc.structureIns(self.Buf, hash.s)
-            self.write(">(")
-            if !env::Production {
-                self.write("_00___file")
-            }
-            self.write(")")
         } else {
-            self.write("_self_.data.as<")
             self.tc.structure(self.Buf, sm.Owner)
-            self.write(">()")
+        }
+        self.write(">()")
+        if ptr {
+            self.write(".alloc")
         }
         for _, mp in m.Params[1:] {
             self.write(", ")
@@ -1186,44 +1156,33 @@ impl ObjectCoder {
         }
     }
 
-    fn traitData(mut &self, mut &hash: &traitHash, mut &old: &Trait) {
-        if len(hash.t.Methods) == 0 {
+    fn traitData(mut &self, mut &hash: &traitHash) {
+        if len(hash.t.Methods) == 0 || len(hash.t.Implemented) == 0 {
             ret
         }
         mut ident := StrBuilder.New(len(hash.t.Ident))
         identCoder.traitDecl(ident, hash.t)
-        if hash.t != old {
-            if old != nil {
-                self.doneIndent()
-                self.indent()
-                self.write("};\n")
-            }
-            self.write("static ")
-            self.writeBytes(unsafe { ident.Buf() })
-            self.write("MptrData ")
-            self.writeBytes(unsafe { ident.Buf() })
-            self.write("_mptr_data[] = {\n")
-            old = hash.t
-            self.addIndent()
-        }
-        self.indent()
-        self.write("{\n")
+        self.write("static ")
+        self.writeBytes(unsafe { ident.Buf() })
+        self.write("MptrData ")
+        self.writeBytes(unsafe { ident.Buf() })
+        self.write("_mptr_data")
+        self.write(conv::Itoa(hash.i))
+        self.write(" {\n")
         self.addIndent()
+        self.indent()
+        self.write(".dealloc=" + deallocatedTypeIdent)
+        i := self.pushDealloc(&TypeKind{Kind: hash.s})
+        self.write(conv::Itoa(i))
+        self.write(",\n")
         self.traitDataMethods(hash.t, hash)
         self.doneIndent()
-        self.indent()
-        self.write("},\n")
+        self.write("};")
     }
 
     fn traitDatas(mut &self) {
-        let mut old: &Trait = nil
         for (_, mut hash) in self.tmap {
-            self.traitData(hash, old)
-        }
-        if old != nil {
-            self.doneIndent()
-            self.indent()
-            self.write("};\n")
+            self.traitData(hash)
         }
     }
 
@@ -1239,7 +1198,6 @@ impl ObjectCoder {
     }
 
     fn decls(mut &self) {
-        self.traitDecls()
         self.structurePlainDecls()
         self.structureDecls()
         self.headPos = self.Buf.Len()
@@ -1248,6 +1206,7 @@ impl ObjectCoder {
         self.write("\n\n")
         self.traitDataTypes()
         self.write("\n\n")
+        self.wrapPos = self.Buf.Len()
         self.traitWrappers()
         self.write("\n\n")
         self.traitDatas()
@@ -1427,6 +1386,7 @@ impl ObjectCoder {
         self.decls()
 
         self.insertBuf(self.resultDecls, self.headPos)
+        self.wrapPos += self.resultDecls.Len()
         self.declPos += self.resultDecls.Len()
 
         self.write("\n")
@@ -1437,7 +1397,8 @@ impl ObjectCoder {
 
         self.anonHashes()
 
-        self.insertBuf(self.deallocObj, self.declPos)
+        self.insertBuf(self.deallocObj, self.wrapPos)
+        self.wrapPos += self.deallocObj.Len()
         self.declPos += self.deallocObj.Len()
 
         self.insertBuf(self.anyObj, self.declPos)

--- a/src/julec/obj/cxx/object.jule
+++ b/src/julec/obj/cxx/object.jule
@@ -923,8 +923,6 @@ impl ObjectCoder {
     fn traitDataTypeMethods(mut &self, mut &t: &Trait) {
         for (_, mut m) in t.Methods {
             mut ins := m.Instances[0]
-            mut p := ins.Params[0]
-            p.Kind = &TypeKind{Kind: t}
             for (i, mut ip) in ins.Params[1:] {
                 if IsAnonIdent(ip.Decl.Ident) {
                     ip.Decl.Ident = "_" + conv::Itoa(i)

--- a/src/julec/obj/cxx/scope.jule
+++ b/src/julec/obj/cxx/scope.jule
@@ -670,7 +670,9 @@ impl scopeCoder {
                     if m.Expr.Kind.Trait() != nil {
                         self.oc.write(".type_is(")
                         self.oc.ec.boolean(expr.Kind.Sptr() != nil)
-                        self.oc.write(", ")
+                        self.oc.write(", (const " + typeCoder.Trait + "::Type*)&")
+                        identCoder.traitDecl(self.oc.Buf, m.Expr.Kind.Trait())
+                        self.oc.write("_mptr_data")
                         self.oc.write(conv::Itoa(self.oc.findTypeOffset(m.Expr.Kind.Trait(), expr.Kind)))
                         self.oc.write(")")
                     } else { // Any type.

--- a/src/julec/obj/cxx/type.jule
+++ b/src/julec/obj/cxx/type.jule
@@ -57,7 +57,7 @@ impl typeCoder {
     const Ptr = "jule::Ptr"
     const Sptr = "jule::Sptr"
     const Slice = "jule::Slice"
-    const Trait = "jule::Trait"
+    const Trait = "jule::Trait2"
     const Array = "jule::Array"
     const Fn = "jule::Fn"
     const Bool = "jule::Bool"
@@ -154,19 +154,6 @@ impl typeCoder {
         self.kind(buf, m.Key)
         buf.WriteByte(',')
         self.kind(buf, m.Val)
-        buf.WriteByte('>')
-    }
-
-    fn traitIdent(mut self, mut &buf: StrBuilder, ident: []byte) {
-        buf.WriteStr(typeCoder.Trait + "<")
-        buf.Write(ident)
-        buf.WriteByte('>')
-    }
-
-    // Generates C++ code of Trait TypeKind.
-    fn traitDecl(mut self, mut &buf: StrBuilder, t: &Trait) {
-        buf.WriteStr(typeCoder.Trait + "<")
-        identCoder.traitDecl(buf, t)
         buf.WriteByte('>')
     }
 
@@ -337,7 +324,7 @@ impl typeCoder {
             self.mapType(buf, k.Map())
             ret
         | k.Trait() != nil:
-            self.traitDecl(buf, k.Trait())
+            buf.WriteStr(typeCoder.Trait)
             ret
         | k.Arr() != nil:
             self.array(buf, k.Arr())

--- a/src/julec/obj/cxx/type.jule
+++ b/src/julec/obj/cxx/type.jule
@@ -57,7 +57,7 @@ impl typeCoder {
     const Ptr = "jule::Ptr"
     const Sptr = "jule::Sptr"
     const Slice = "jule::Slice"
-    const Trait = "jule::Trait2"
+    const Trait = "jule::Trait"
     const Array = "jule::Array"
     const Fn = "jule::Fn"
     const Bool = "jule::Bool"


### PR DESCRIPTION
This PR implements a new trait logic. New approach to handle traits.

This new approach focuses on increasing memory efficiency and improving performance. It achieves this with some important differences compared to the current trait implementation.

**About Current Implementation**

The current implementation uses a relatively efficient method of handling traits. But here we are.
Some improvements were possible.

According to the approach of the current implementation, each trait instance should have 4 different data;
- **Allocation**
Allocation is a pointer to the data itself that the trait stores. Managed by GC. The current implementation handles this well. If a pointer that is already traced by the GC is passed to the trait, for example a smart pointer, the trait uses it by directly referencing that smart pointer rather than making a new allocation. This helps reduce memory allocations and increases efficiency.
- **Pointer State**
Traits may take both a smart pointer or a normal instance for supported types. Accordingly, the deallocation method and type comparison also vary. If separate code was generated for both forms with and without smart pointers, this could significantly increase the size and compilation time of the executable. Since it does not contribute much to the runtime cost, it stores whether the stored data is a smart pointer or not with a simple boolean flag. In this way, it is sufficient to generate a single handler for each form of trait type.
- **Deallocator Function**
Allocation pointer is stored without any explicit type as required by dynamic programming. Therefore, when it comes to deallocation, it needs to be handled in a special function. The deallocator function is not handled by the compiler. C++'s generic types and compiler are relied upon. This is clearly bad. Because the generated code requires the trait data type to be transferred to C++ code as a generic type. This leads to the creation of a new instance of the trait container class for each trait. It's clearly something that negatively impacts executable size, and this is all to enable a single generic type to create a deallocator function. It should be replaced.
- **Type Offset**
The compiler generates a map with an array created on the stack for each trait type. In order to know which wrapper in which array element it should point to at runtime, it must add the offset data of the required type to the trait container class. This isn't that bad, but it does involve unnecessary overhead: a pointer arithmetic for the required type is executed every time trait is used. This is simply like `array_ptr + offset`. 

**About New Implementation**

The new approach is very similar to the current practice but includes some significant efficiency improvements.

According to the approach of the new implementation, each trait instance should have 3 different data;

- **Allocation**
No update. Efficient enough.
- **Pointer State**
No update. Efficient enough.
- **Type Pointer**
The new approach maintains a general pointer and this pointer is not traced by the GC because it is guaranteed to always will point to static memory that will be available for the lifetime of the program. This pointer points directly to the type handler structure automatically created by the compiler. The only difference is that this handler structure now includes the deallocator function required for the type. The deallocator function is the first field of the structure. In this way, with a simple reinterpretation, the trait container can call the deallocator function when necessary. Each time trait is used, the type pointer is reinterpreted for the correct type, providing direct access to the required function, without the overhead of the previous pointer arithmetic. With this approach, there is no longer a need for separate type offset and deallocator function pointer datas.