### PR TITLE
julec: fix help function to print formatted string

### DIFF
--- a/src/julec/main.jule
+++ b/src/julec/main.jule
@@ -56,7 +56,7 @@ fn help(&args: []str) {
 			s.WriteByte('\n')!
 		}
 	}
-	println(s)
+	println(s.Str())
 }
 
 // Command: julec version


### PR DESCRIPTION
<!--
    Thank you for contributing to Jule project!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing Guidelines: https://jule.dev/contribute
-->

### Description
Fixed incorrect behavior of the help function for julec.

<!-- Describe what this PR introduces. -->
<!-- If any, link any issue that this PR solves. -->

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [ ] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing Guidelines](https://jule.dev/contribute) of the project and its resources/related pages.

### Screenshots (if any)

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| ![image](https://github.com/user-attachments/assets/7274bab8-0514-425b-9a68-73b7ef62322b) | ![image](https://github.com/user-attachments/assets/9a72bc17-aa3f-44b5-aec3-547628e8701e) |

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
