### PR TITLE
julec: improve consistency in `julec` and `julec help`

### DIFF
--- a/src/julec/main.jule
+++ b/src/julec/main.jule
@@ -20,7 +20,7 @@ const CmdMod = "mod"
 
 // Map for "julec help" command.
 static HelpMap: [...][2]str = [
-	[CmdHelp, "Show help"],
+	[CmdHelp, "Show the list of available commands"],
 	[CmdVersion, "Show version"],
 	[CmdTool, "Tools for effective Jule"],
 	[CmdJulenv, "Show information about native jule environment"],
@@ -32,7 +32,7 @@ fn printErrorMessage(msg: str) {
 }
 
 // Command: julec help
-fn help(&args: []str) {
+fn help(&args: []str, pan: int) {
 	if len(args) > 2 {
 		printErrorMessage("invalid command: " + args[2])
 		ret
@@ -50,6 +50,7 @@ fn help(&args: []str) {
 	s.Grow(1 << 5)
 	const Space = 5 // Space of between command name and description.
 	for i, part in HelpMap {
+		s.WriteStr(strings::Repeat(" ", pan))!
 		s.WriteStr(part[0])!
 		s.WriteStr(strings::Repeat(" ", (max-len(part[0]))+Space))!
 		s.WriteStr(part[1])!
@@ -95,8 +96,8 @@ fn toolDistarch() {
 fn tool(&args: []str) {
 	if len(args) == 2 {
 		println(`tool commands:
- distos     Lists all supported operating systems
- distarch   Lists all supported architects`)
+ distos     List all supported operating systems
+ distarch   List all supported architects`)
 		ret
 	} else if len(args) > 3 {
 		printErrorMessage("invalid command: " + args[3])
@@ -130,7 +131,7 @@ fn julenv(&args: []str) {
 // Command: julec mod
 fn mod(&args: []str) {
 	if len(args) == 2 {
-		println("command is not given, try julec mod init")
+		println("no command given, try julec mod init")
 		ret
 	}
 
@@ -142,7 +143,7 @@ fn mod(&args: []str) {
 	match args[2] {
 	| "init": // julec mod init
 		os::File.Write(jule::ModuleFile, [], 0o660) else {
-			printErrorMessage("module could not generated because of a problem")
+			printErrorMessage("module could not be generated")
 		}
 	|:
 		printErrorMessage("invalid command: " + args[2])
@@ -154,7 +155,7 @@ fn mod(&args: []str) {
 fn processCommand(&args: []str): bool {
 	match args[1] {
 	| CmdHelp:
-		help(args)
+		help(args, 0)
 	| CmdVersion:
 		version(args)
 	| CmdTool:
@@ -170,20 +171,15 @@ fn processCommand(&args: []str): bool {
 	ret true
 }
 
-fn showInfo() {
+fn showInfo(args: []str) {
 	println(
-		`JuleC is a tool for Jule source code and developers.
+		`JuleC is the Jule programming language compiler.
 
-Commands:
-    help          Show help
-    version       Show version
-    tool          Tools for effective Jule
-    julenv        Show information about native jule environment
-    mod           Module management
-
+Commands:`)
+	help(args, 4)
+	println(`
 Compilation:
-    julec [OPTIONS] INPUT
-`)
+    julec [OPTIONS] INPUT`)
 }
 
 fn main() {
@@ -192,7 +188,7 @@ fn main() {
 	// Not started with arguments.
 	// Here is "2" but "args" always have one element for store program name.
 	if len(args) < 2 {
-		showInfo()
+		showInfo(args)
 		ret
 	}
 


### PR DESCRIPTION
changes:
-refactored the code to use the `help()` instead of hard-coding commands when invoking `julec` with no arguments
-changed grammar to be more consistent

Signed-off-by: Adam Perkowski <adas1per@protonmail.com>
