### PR TITLE
julec: add `--verbose` (`-v`) flag

### DIFF
--- a/src/julec/compile.jule
+++ b/src/julec/compile.jule
@@ -21,6 +21,7 @@ use "std/strings"
 static mut OutDir = "dist"
 static mut OutName = "ir.cpp"
 static mut Out = ""
+static mut Verbose = false
 
 fn init() {
 	// Configure compiler to default by platform
@@ -116,6 +117,10 @@ fn pushCompCmdClang(mut &cmd: strings::Builder) {
 	} else {
 		cmd.WriteStr("-O0 ")! // No optimization.
 	}
+
+	if Verbose {
+		cmd.WriteStr("--verbose ")!
+	}
 }
 
 fn pushCompCmdGcc(mut &cmd: strings::Builder) {
@@ -140,6 +145,10 @@ fn pushCompCmdGcc(mut &cmd: strings::Builder) {
 		cmd.WriteStr("-fomit-frame-pointer ")! // Do not use frame pointer.
 	} else {
 		cmd.WriteStr("-O0 ")! // No optimization.
+	}
+
+	if Verbose {
+		cmd.WriteStr("--verbose ")!
 	}
 }
 
@@ -289,6 +298,7 @@ fn checkFlags(&args: []str): []str {
 	fs.AddVar[str](unsafe { (&str)(&opt) }, "opt", 0, "Optimization level")
 	fs.AddVar[str](unsafe { (&str)(&target) }, "target", 0, "Target system")
 	fs.AddVar[str](unsafe { (&str)(&Out) }, "out", 'o', "Output identifier")
+	fs.AddVar[bool](unsafe { (&bool)(&Verbose) }, "verbose", 'v', "Verbose logging")
 	fs.AddVar[bool](unsafe { (&bool)(&env::Shadowing) }, "shadowing", 0, "Allow shadowing")
 	fs.AddVar[bool](unsafe { (&bool)(&env::Transpilation) }, "transpile", 't', "Transpile code")
 	fs.AddVar[str](unsafe { (&str)(&env::Compiler) }, "compiler", 0, "Backend compiler")


### PR DESCRIPTION
hey!
this adds a verbose logging option and passes it along to backend compilers.
i'm also thinking if we should implement verbose logging for IR generation, etc.
when this is merged, i'll open a pr on [julelang/manual](https://github.com/julelang/manual).
