### PR TITLE
all, ci: fix some typos & update `_typos.yml`

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,12 +1,8 @@
 # This TOML file used by the julelang/jule and julelang/manual repositories.
 # Configuration is common.
+[files]
+extend-exclude = ["std/html/entity.jule"]
+
 [default]
-extend-ignore-identifiers-re = [
-    "ue", "nd", "lok", "Thm",
-    "sur", "leasure", "asure", "nulll", "finf",
-    "iy", "ERROR_FILENAME_EXCED_RANGE", "FLE",
-    "nam", "ND", "eisDST", "inh", "Vai", "VAI",
-    "fo", "hel", "IST", "Commun", "Ofr", "becaus",
-    "curren", "infintie", "ofr", "olt", "pluse",
-    "pointint", "lates", "isuses", "infinit"
-]
+extend-words = { ue = "ue", nd = "nd", lok = "lok", Thm = "Thm", sur = "sur", leasure = "leasure", asure = "asure", nulll = "nulll", finf = "finf", iy = "iy", ERROR_FILENAME_EXCED_RANGE = "ERROR_FILENAME_EXCED_RANGE", FLE = "FLE", nam = "nam", ND = "ND", eis = "eis", inh = "inh", Vai = "Vai", VAI = "VAI", fo = "fo", hel = "hel", IST = "IST", Commun = "Commun", Ofr = "Ofr", becaus = "becaus", curren = "curren", infintie = "infintie", ofr = "ofr", olt = "olt", pluse = "pluse", pointint = "pointint", lates = "lates", isuses = "isuses", infinit = "infinit" }
+extend-identifiers = { ERROR_FILENAME_EXCED_RANGE = "ERROR_FILENAME_EXCED_RANGE" }

--- a/src/julec/obj/cxx/object.jule
+++ b/src/julec/obj/cxx/object.jule
@@ -773,7 +773,7 @@ impl ObjectCoder {
 		self.write("\n")
 		self.write("// Time: ")
 		self.write(t.Format("2006-01-02 (YYYY/MM/DD) 3:04PM MST"))
-		self.write("\n//\n// Recomended Compile Command;\n// ")
+		self.write("\n//\n// Recommended Compile Command;\n// ")
 		self.write(self.info.Compiler)
 		self.write(" ")
 		self.write(self.info.CompilerCommand)

--- a/std/encoding/json/decode.jule
+++ b/std/encoding/json/decode.jule
@@ -331,7 +331,7 @@ impl jsonDecoder {
 			ret
 		}
 		self.pushParseState(parseObject) else { error(error) }
-		// Consider string and dynamic JSON vlaue types as quoted. Directly assign string as key.
+		// Consider string and dynamic JSON value types as quoted. Directly assign string as key.
 		const quoted = keyT.Kind() == comptime::Str || keyT == valueT || keyT == stringT
 		for {
 			self.skipSpace()

--- a/std/jule/sema/eval.jule
+++ b/std/jule/sema/eval.jule
@@ -82,7 +82,7 @@ struct ValueSym {
 	Value: &Value
 }
 
-// Informations about expressions that evaluating for assignments.
+// Information about expressions that evaluating for assignments.
 struct target {
 	ignored: bool // whether the destination ignores the evaluated expression.
 	mutable: bool // Will be assigned to the mutable storage.
@@ -892,7 +892,7 @@ impl eval {
 				goto autoDetermine
 			}
 			// If prefix type is a strict type alias, we have to use its
-			// underliying structure type for the value.
+			// underlying structure type for the value.
 			if v != nil {
 				mut strct := self.prefix.SoftStruct()
 				if strct != nil && strct.Source != nil {

--- a/std/sys/errors_unix.jule
+++ b/std/sys/errors_unix.jule
@@ -6,7 +6,7 @@ use "std/internal/conv"
 
 cpp let errno: int
 
-// Underliying type of Errno for UNIX.
+// Underlying type of Errno for UNIX.
 type errno = uintptr
 
 fn getLastErrno(): Errno { ret Errno(cpp.errno) }

--- a/std/sys/errors_windows.jule
+++ b/std/sys/errors_windows.jule
@@ -290,7 +290,7 @@ static errors: [...]str = [
 	"not supported by windows",
 ]
 
-// Underliying type of Errno for Windows.
+// Underlying type of Errno for Windows.
 type errno = uintptr
 
 fn getLastErrno(): Errno { ret Errno(GetLastError()) }


### PR DESCRIPTION
turns out that the `extend-ignore-identifiers-re` config field wasn't working properly and the correct way to "ignore" "words" is with `extend-words`

ref: https://github.com/crate-ci/typos/blob/master/docs/reference.md
