### PR TITLE
runtime: reimplement channels

### DIFF
--- a/src/julec/obj/cxx/expr.jule
+++ b/src/julec/obj/cxx/expr.jule
@@ -2006,8 +2006,9 @@ impl exprCoder {
 			f = ins.FindMethod("tryRecv", Static).Instances[0]
 		}
 		identCoder.funcIns(&self.oc.Buf, f)
-		self.oc.write("(")
+		self.oc.write("((")
 		self.possibleRefExpr(m.Expr.Model)
+		self.oc.write(")")
 		if block {
 			self.oc.write(".must_ok(\"")
 			self.oc.locInfo(m.Token)
@@ -2036,8 +2037,9 @@ impl exprCoder {
 			f = ins.FindMethod("trySend", Static).Instances[0]
 		}
 		identCoder.funcIns(&self.oc.Buf, f)
-		self.oc.write("(")
+		self.oc.write("((")
 		self.possibleRefExpr(m.Chan.Model)
+		self.oc.write(")")
 		if block {
 			self.oc.write(".must_ok(\"")
 			self.oc.locInfo(m.Token)

--- a/src/julec/obj/cxx/scope.jule
+++ b/src/julec/obj/cxx/scope.jule
@@ -1453,6 +1453,10 @@ impl scopeCoder {
 		}
 
 		self.oc.indent()
+		self.oc.write("{\n")
+		self.oc.addIndent()
+
+		self.oc.indent()
 		self.oc.tc.asSptr2(&self.oc.Buf, typeUintptr)
 		self.oc.write(" __chanArr[] = {")
 		self.oc.write(chanArr.Str())
@@ -1480,6 +1484,10 @@ impl scopeCoder {
 		self.oc.write(", ")
 		self.oc.ec.boolean(block)
 		self.oc.write(");\n")
+
+		self.oc.doneIndent()
+		self.oc.indent()
+		self.oc.write("}\n")
 
 		self.oc.indent()
 		self.oc.write("switch (__selectIndex) {\n")

--- a/src/julec/obj/cxx/scope.jule
+++ b/src/julec/obj/cxx/scope.jule
@@ -1255,148 +1255,262 @@ impl scopeCoder {
 			ret
 		}
 
-		writeChanExpr := fn(mut v: sema::Expr) {
-			match type v {
-			| &sema::ChanRecv:
-				mut recv := v.(&sema::ChanRecv)
-				self.oc.ec.chanRecv(recv, fn|| self.oc.write("&ok"), false)
-				self.oc.write(";\n")
-			| &sema::ChanSend:
-				mut send := v.(&sema::ChanSend)
-				self.oc.write("ok = ")
-				self.oc.ec.chanSend(send, false)
-				self.oc.write(";\n")
-			|:
-				panic("unreachable")
-			}
+		mut scase := ""
+		mut scaseCh := ""
+		mut scaseData := ""
+		mut scaseTryRecv := ""
+		mut scaseTryRecvImmediate := ""
+		mut scaseTrySend := ""
+		mut scaseTrySendImmediate := ""
+		{
+			mut scaseIns := meta::Program.Runtime.Scase
+			let mut scaseBuf: strings::Builder
+			self.oc.tc.structureIns(&scaseBuf, scaseIns)
+			scase = scaseBuf.Str()
+			scaseBuf.Clear()
+			identCoder.field(&scaseBuf, scaseIns.FindField("ch").Decl)
+			scaseCh = scaseBuf.Str()
+			scaseBuf.Clear()
+			identCoder.field(&scaseBuf, scaseIns.FindField("data").Decl)
+			scaseData = scaseBuf.Str()
+			scaseBuf.Clear()
+			identCoder.field(&scaseBuf, scaseIns.FindField("tryRecv").Decl)
+			scaseTryRecv = scaseBuf.Str()
+			scaseBuf.Clear()
+			identCoder.field(&scaseBuf, scaseIns.FindField("tryRecvImmediate").Decl)
+			scaseTryRecvImmediate = scaseBuf.Str()
+			scaseBuf.Clear()
+			identCoder.field(&scaseBuf, scaseIns.FindField("trySend").Decl)
+			scaseTrySend = scaseBuf.Str()
+			scaseBuf.Clear()
+			identCoder.field(&scaseBuf, scaseIns.FindField("trySendImmediate").Decl)
+			scaseTrySendImmediate = scaseBuf.Str()
 		}
+
+		let mut chanArr: strings::Builder
+		let mut recvArr: strings::Builder
+		let mut sendArr: strings::Builder
+		let mut nchan: int
+		let mut nrecv: int
+		let mut nsend: int
 
 		self.oc.write("{\n")
 		self.oc.addIndent()
+
 		self.oc.indent()
-		mut endLabel := strings::Builder{}
-		identCoder.matchEnd(&endLabel, uintptr(slct))
-		if block {
-			self.oc.write("while (true) {\n")
-			self.oc.addIndent()
-			self.oc.indent()
+		self.oc.write(typeInt)
+		self.oc.write(" __selectIndex;\n")
+
+		registerChan := fn(mut &buf: *strings::Builder, mut ch: &sema::Chan, data: str, n: int) {
+			buf.WriteStr(scase)!
+			buf.WriteStr("{.")!
+			buf.WriteStr(scaseCh)!
+			buf.WriteStr("=&__chanArr[")!
+			buf.WriteStr(conv::Itoa(n))!
+			buf.WriteStr("], .")!
+			if data != "" {
+				buf.WriteStr(scaseData)!
+				buf.WriteStr("=(")!
+				buf.WriteStr(typeUintptr)!
+				buf.WriteStr(")")!
+				if data[0] == '*' { // Data is pointer already.
+					buf.WriteStr(data[1:])!
+				} else {
+					buf.WriteByte('&')!
+					buf.WriteStr(data)!
+				}
+				buf.WriteStr(", .")!
+			}
+			mut ins := obj::FindStructGenericInstance(meta::Program.Runtime.Pchan, ch.Value)
+			const Extern = false
+			mut tryRecv := ins.FindMethod("tryRecv", Extern).Instances[0]
+			mut tryRecvImmediate := ins.FindMethod("tryRecvImmediate", Extern).Instances[0]
+			mut trySend := ins.FindMethod("trySend", Extern).Instances[0]
+			mut trySendImmediate := ins.FindMethod("trySendImmediate", Extern).Instances[0]
+
+			buf.WriteStr(scaseTryRecv)!
+			buf.WriteStr("=(")!
+			buf.WriteStr(typeUintptr)!
+			buf.WriteByte(')')!
+			identCoder.funcIns(buf, tryRecv)
+			buf.WriteStr(", .")!
+			buf.WriteStr(scaseTryRecvImmediate)!
+			buf.WriteStr("=(")!
+			buf.WriteStr(typeUintptr)!
+			buf.WriteByte(')')!
+			identCoder.funcIns(buf, tryRecvImmediate)
+			buf.WriteStr(", .")!
+			buf.WriteStr(scaseTrySend)!
+			buf.WriteStr("=(")!
+			buf.WriteStr(typeUintptr)!
+			buf.WriteByte(')')!
+			identCoder.funcIns(buf, trySend)
+			buf.WriteStr(", .")!
+			buf.WriteStr(scaseTrySendImmediate)!
+			buf.WriteStr("=(")!
+			buf.WriteStr(typeUintptr)!
+			buf.WriteByte(')')!
+			identCoder.funcIns(buf, trySendImmediate)
+
+			buf.WriteByte('}')!
 		}
-		self.oc.write("for (int attempt = 0; attempt < 5; ++attempt) {\n")
-		self.oc.addIndent()
-		self.oc.indent()
-		self.oc.write(typeInt)
-		self.oc.write(" __randidx = (")
-		self.oc.write(typeInt)
-		self.oc.write(")")
-		identCoder.funcIns(&self.oc.Buf, meta::Program.Runtime.Rand)
-		self.oc.write("();\n")
-		self.oc.indent()
-		self.oc.write("for (")
-		self.oc.write(typeInt)
-		self.oc.write(" __idx = 0; __idx < ")
-		lencases := conv::Itoa(len(slct.Cases))
-		self.oc.write(lencases)
-		self.oc.write("LL; ++__idx) {\n")
-		self.oc.addIndent()
-		self.oc.indent()
-		self.oc.write(typeInt)
-		self.oc.write(" __offset = (__randidx+__idx)%")
-		self.oc.write(lencases)
-		self.oc.write(";\n")
-		self.oc.indent()
-		self.oc.write(typeBool)
-		self.oc.write(" ok = false;\n")
-		self.oc.indent()
-		self.oc.write("switch (__offset) {\n")
-		for (i, mut case) in slct.Cases {
-			caseNum := conv::Itoa(i)
-			self.oc.indent()
-			self.oc.write("case ")
-			self.oc.write(caseNum)
-			self.oc.write("LL:\n")
-			self.oc.addIndent()
-			self.oc.indent()
-			self.oc.write("{\n")
-			self.oc.indent()
-			let mut varRecv: &sema::Var
-			let mut assignRecv: &sema::Assign
+
+		// We have to evaluate all expressions of the cases.
+		for (_, mut case) in slct.Cases {
+			caseHex := conv::FormatUint(u64(uintptr(case)), 16)
+			let mut data: str
+			let mut value: sema::Expr
 			match type case.Stmt {
 			| &sema::Value:
-				mut v := case.Stmt.(&sema::Value)
-				writeChanExpr(v.Model)
+				value = case.Stmt.(&sema::Value).Model
+				match type value {
+				| &sema::ChanSend:
+					mut cs := value.(&sema::ChanSend)
+
+					data = "__var_" + caseHex
+
+					// Evaluate the data to be sent.
+					self.oc.indent()
+					self.oc.tc.kind(&self.oc.Buf, cs.Data.Type)
+					self.oc.write(" ")
+					self.oc.write(data)
+					self.oc.write("=")
+					self.oc.ec.possibleRefExpr(cs.Data.Model)
+					self.oc.write(";\n")
+				| &sema::ChanRecv:
+					// no-op
+				|:
+					panic("unreachable")
+				}
 			| &sema::Var:
-				// Variable declaration. Only possible with receive expression.
-				varRecv = case.Stmt.(&sema::Var)
-				self.oc.tc.kind(&self.oc.Buf, varRecv.ValueSym.Value.Type)
-				self.oc.write(" __recv_data")
-				self.oc.write(caseNum)
-				self.oc.write(" = ")
-				writeChanExpr(varRecv.ValueSym.Value.Model)
+				mut v := case.Stmt.(&sema::Var)
+
+				// Declare the variable to receive the data.
+				self.oc.indent()
+				self.oc.varInitExpr(v, nil)
+				self.oc.write("\n")
+
+				let mut varBuf: strings::Builder
+				identCoder.var(&varBuf, v)
+				data = varBuf.Str()
+				value = v.ValueSym.Value.Model
 			| &sema::Assign:
-				assignRecv = case.Stmt.(&sema::Assign)
-				self.oc.tc.kind(&self.oc.Buf, assignRecv.Right.Type)
-				self.oc.write(" __recv_data")
-				self.oc.write(caseNum)
-				self.oc.write(" = ")
-				writeChanExpr(assignRecv.Right.Model)
+				mut assign := case.Stmt.(&sema::Assign)
+
+				data = "*__var_" + caseHex // * prefix is a placeholder for memory address data.
+				value = assign.Right.Model
+
+				// Evaluate the memory address to receive the data.
+				self.oc.indent()
+				self.oc.tc.kind(&self.oc.Buf, assign.Left.Type)
+				self.oc.write(" ")
+				self.oc.write(data)
+				self.oc.write("=&")
+				self.oc.ec.possibleRefExpr(assign.Left.Model)
+				self.oc.write(";\n")
 			|:
 				panic("unreachable")
 			}
-			self.oc.indent()
-			self.oc.write("if (!ok) continue;\n")
-			self.oc.indent()
-			if varRecv != nil {
-				self.oc.varInitExpr(varRecv, fn|| {
-					self.oc.write("__recv_data")
-					self.oc.write(caseNum)
-				})
-				self.oc.write("\n")
-				self.oc.indent()
+
+			let mut chanValue: &sema::Value
+			match type value {
+			| &sema::ChanSend:
+				if nsend > 0 {
+					sendArr.WriteStr(", ")!
+				}
+				nsend++
+
+				mut cs := value.(&sema::ChanSend)
+				chanValue = cs.Chan
+
+				registerChan(&sendArr, chanValue.Type.Chan(), data, nchan)
+			| &sema::ChanRecv:
+				if nrecv > 0 {
+					recvArr.WriteStr(", ")!
+				}
+				nrecv++
+
+				mut cr := value.(&sema::ChanRecv)
+				chanValue = cr.Expr
+
+				registerChan(&recvArr, chanValue.Type.Chan(), data, nchan)
+			|:
+				panic("unreachable")
 			}
-			if assignRecv != nil {
-				mut expr := compExpr("__recv_data" + caseNum)
-				assignRecv.Right.Model = unsafe { *(*sema::Expr)(&expr) }
-				self.assign(assignRecv)
-				self.oc.write(";\n")
-				self.oc.indent()
+
+			if nchan > 0 {
+				chanArr.WriteStr(", ")!
 			}
-			if len(case.Scope.Stmts) > 0 {
-				self.scope(case.Scope)
-				self.oc.write("\n")
-				self.oc.indent()
-			}
-			self.oc.write("}\n")
+			nchan++
+			n := self.oc.Buf.Len()
+			self.oc.ec.possibleRefExpr(chanValue.Model)
+			mut buf := unsafe { self.oc.Buf.Buf() }
+			chanArr.Write(buf[n:])!
+			unsafe { self.oc.Buf.SetBuf(buf[:n]) }
+			chanArr.WriteStr(".as<")!
+			chanArr.WriteStr(typeUintptr)!
+			chanArr.WriteStr(">()")!
+		}
+
+		self.oc.indent()
+		self.oc.tc.asSptr2(&self.oc.Buf, typeUintptr)
+		self.oc.write(" __chanArr[] = {")
+		self.oc.write(chanArr.Str())
+		self.oc.write("};\n")
+
+		self.oc.indent()
+		self.oc.write(scase)
+		self.oc.write(" __caseArr[] = {")
+		self.oc.write(recvArr.Str())
+		if nrecv > 0 && nsend > 0 {
+			self.oc.write(", ")
+			self.oc.write(sendArr.Str())
+		}
+		self.oc.write("};\n")
+
+		self.oc.indent()
+		self.oc.write("__selectIndex = ")
+		identCoder.funcIns(&self.oc.Buf, meta::Program.Runtime.Runselect)
+		self.oc.write("(__chanArr, ")
+		self.oc.write(conv::Itoa(nchan))
+		self.oc.write(", __caseArr, ")
+		self.oc.write(conv::Itoa(nrecv))
+		self.oc.write(", ")
+		self.oc.write(conv::Itoa(nsend))
+		self.oc.write(", ")
+		self.oc.ec.boolean(block)
+		self.oc.write(");\n")
+
+		self.oc.indent()
+		self.oc.write("switch (__selectIndex) {\n")
+		for (i, mut case) in slct.Cases {
 			self.oc.indent()
-			self.oc.write("goto ")
-			self.oc.write(endLabel.Str())
-			self.oc.write(";\n")
+			self.oc.write("case ")
+			self.oc.write(conv::Itoa(i))
+			self.oc.write(":\n")
+			self.oc.addIndent()
+			self.oc.indent()
+			self.scope(case.Scope)
+			self.oc.write("\n")
+			self.oc.indent()
+			self.oc.write("break;\n")
 			self.oc.doneIndent()
 		}
-		self.oc.indent()
-		self.oc.write("}\n")
-		self.oc.doneIndent()
-		self.oc.indent()
-		self.oc.write("}\n")
-		self.oc.doneIndent()
-		self.oc.indent()
-		self.oc.write("}\n")
-		self.oc.indent()
-		if block {
-			identCoder.funcIns(&self.oc.Buf, meta::Program.Runtime.Osyield)
-			self.oc.write("();\n")
-			self.oc.doneIndent()
+		if slct.Default != nil {
 			self.oc.indent()
-			self.oc.write("}\n")
+			self.oc.write("default:\n")
+			self.oc.addIndent()
 			self.oc.indent()
-		} else if len(slct.Default.Scope.Stmts) > 0 {
 			self.scope(slct.Default.Scope)
 			self.oc.write("\n")
 			self.oc.indent()
+			self.oc.write("break;\n")
+			self.oc.doneIndent()
 		}
-		self.oc.doneIndent()
 		self.oc.indent()
-		self.oc.write(endLabel.Str())
-		self.oc.write(":;\n")
+		self.oc.write("}\n")
+
+		self.oc.doneIndent()
 		self.oc.indent()
 		self.oc.write("}")
 	}

--- a/src/julec/obj/cxx/type.jule
+++ b/src/julec/obj/cxx/type.jule
@@ -91,6 +91,12 @@ impl typeCoder {
 		buf.WriteByte('>')!
 	}
 
+	fn asSptr2(mut *self, mut &buf: *strings::Builder, valueTyp: str) {
+		buf.WriteStr(typePtr + "<")!
+		buf.WriteStr(valueTyp)!
+		buf.WriteByte('>')!
+	}
+
 	// Generates C++ code of smart pointer type.
 	fn sptr(mut *self, mut &buf: *strings::Builder, mut sptr: &sema::Sptr) {
 		buf.WriteStr(typePtr + "<")!

--- a/src/julec/obj/meta/meta.jule
+++ b/src/julec/obj/meta/meta.jule
@@ -55,6 +55,7 @@ struct Runtime {
 	Zprint:          &sema::FuncIns
 	Zprintln:        &sema::FuncIns
 	Emptyselect:     &sema::FuncIns
+	Runselect:       &sema::FuncIns
 	RCAdd:           &sema::FuncIns
 	RCLoad:          &sema::FuncIns
 	RCDrop:          &sema::FuncIns
@@ -88,6 +89,7 @@ struct Runtime {
 	Pchan:       &sema::Struct
 	Cmplx64:     &sema::StructIns
 	Cmplx128:    &sema::StructIns
+	Scase:       &sema::StructIns
 }
 
 // Metadata for common objects.
@@ -138,6 +140,7 @@ fn CollectRuntime(mut ir: &obj::IR): &Runtime {
 	meta.Zprint = obj::RuntimeFindFunc(p, "zprint").Instances[0]
 	meta.Zprintln = obj::RuntimeFindFunc(p, "zprintln").Instances[0]
 	meta.Emptyselect = obj::RuntimeFindFunc(p, "emptyselect").Instances[0]
+	meta.Runselect = obj::RuntimeFindFunc(p, "runselect").Instances[0]
 	meta.RCAdd = obj::RuntimeFindFunc(p, "_RCAdd").Instances[0]
 	meta.RCLoad = obj::RuntimeFindFunc(p, "_RCLoad").Instances[0]
 	meta.RCDrop = obj::RuntimeFindFunc(p, "_RCDrop").Instances[0]
@@ -172,6 +175,7 @@ fn CollectRuntime(mut ir: &obj::IR): &Runtime {
 	meta.Pchan = obj::RuntimeFindStruct(p, "pchan")
 	meta.Cmplx64 = obj::RuntimeFindStruct(p, "_cmplx64").Instances[0]
 	meta.Cmplx128 = obj::RuntimeFindStruct(p, "_cmplx128").Instances[0]
+	meta.Scase = obj::RuntimeFindStruct(p, "scase").Instances[0]
 
 	ret meta
 }

--- a/std/runtime/chan.jule
+++ b/std/runtime/chan.jule
@@ -4,16 +4,12 @@
 
 use "std/internal/runtime"
 
-// Ideal threshold for the channel MPMC queue enqueue/dequeue time.
-// If MPMC queue is failed and reached to threshold, then consider as fail.
-const chanThreshold = 1e6
-
 // The low-level base channel implementation of the language runtime.
 // The generic type represents the data type of the channel. Instances required
 // at compile-time are automatically instantiated by the compiler.
 // Any channel algorithms that require generic types should be defined under
-// this structure. A fchan should not be copied after being used.
-// The compiler creates channels in the background using the [fchan[T].new].
+// this structure. A pchan should not be copied after being used.
+// The compiler creates channels in the background using the [pchan[T].new].
 // Behind the scenes, each channel is treated as a smart pointer.
 struct pchan[T] {
 	lock:   qmutex       // Protects all fields, except lock-free ones.
@@ -26,7 +22,7 @@ struct pchan[T] {
 
 impl pchan {
 	#disable nilptr
-	fn new(cap: int): &pchan[T] {
+	fn new(mut cap: int): &pchan[T] {
 		mut ch := new(pchan[T])
 		if cap < 0 {
 			panic("runtime: invalid channel buffer size, it was <0")
@@ -41,25 +37,122 @@ impl pchan {
 	// Closes the channel.
 	#disable nilptr
 	fn close(mut *self) {
-		self.queue.close() // Lock-free.
+		self.queue.close()
+
 		self.lock.lock()
+
+		// Set state as closed.
 		self.closed = 1
-		unparkAll(&self.recvq) // Release all readers.
-		unparkAll(&self.sendq) // Release all writers (they will panic).
+
+		// If channel is buffered, hand-off enqueued data to the waiting receivers.
+		if self.cap > 0 {
+			for {
+				mut recvp := self.recvq.dequeueChan()
+				if recvp == nil {
+					break
+				}
+				let mut data: T
+				self.queue.dequeue(&data)
+				if recvp.stack != 0 {
+					unsafe { *(*T)(recvp.stack) = data }
+				}
+				recvp.stack = 0  // Set stack pointer to zero, marked as received.
+				recvp.ticket = 0 // Set ticket to zero, marked as received for select statements.
+				recvp.parker.unpark()
+			}
+		}
+
+		// If channel is unbuffered, handle it like hand-off.
+		// Unbuffered channels works with direct data hand-off.
+		// Closing channel will notify them spuriously.
+		// Since channel is closed, it can't try again.
+		// Clear spurious wakeup signs to avoid try again in select statements.
+		unparkAll(&self.recvq, self.cap == 0) // Unpark all receivers.
+		unparkAll(&self.sendq, false)         // Unpark all senders (they will panic).
+
 		self.lock.unlock()
+	}
+
+	// Final implementation of the [pchan.send] function.
+	// Focuses on parked threads.
+	// Mutex must be locked. It will be released before return.
+	// Reports whether the stack pointer is used (data handled).
+	#disable nilptr
+	fn sendFinal(mut *self, mut &data: *T): (spurious: bool) {
+		// Before park the thread, check for a waiting receiver, if any.
+		// If we lucky, write data to the stack of the receiver and return.
+		mut recvp := self.recvq.dequeueChan()
+		if recvp != nil {
+			self.lock.unlock()
+			if recvp.stack != 0 {
+				unsafe { *(*T)(recvp.stack) = *data }
+				recvp.stack = 0 // Set stack pointer to zero, marked as sent.
+			}
+			recvp.ticket = 0 // Set ticket to zero, marked as sent for select statements.
+			recvp.parker.unpark()
+			ret false
+		}
+
+		// We have to park the thread.
+		mut thread := acquireThread()
+		mut stackp := parkerList{}
+		mut p := unsafe { (&parkerList)(&stackp) }
+		p.parker = thread.parker
+		p.stack = uintptr(data)
+		self.sendq.enqueue(p)
+		park2(&(*thread), uintptr(&self.lock), &(*p.parker), reasonSend)
+		ret isSpuriousWake(&stackp)
 	}
 
 	// Implementation of the buffered [pchan.send] function.
 	#disable nilptr
 	fn sendBuffered(mut *self, mut data: T) {
 		for {
-			enq, closed := self.queue.enqueue(&data)
+			// Fast-path: enqueue data using the lock-free MPMC queue.
+			mut enq, mut closed, full := self.queue.enqueue(&data)
+			// If queue is full now (or with new sent data), wake a receiver.
+			// This is a spurious wake, do not write the data to it's stack pointer.
+			// It must be try to receive it from the queue.
+			//
+			// This is needed because all receivers might be parked.
+			// Queue is full and no reader, deadlock. Bad.
+			if full {
+				self.lock.lock()
+				mut recvp := self.recvq.dequeueChan()
+				self.lock.unlock()
+				if recvp != nil {
+					recvp.parker.unpark()
+				}
+			}
+			// Enqueued, return.
 			if enq {
 				ret
 			}
 			if closed {
 				panic("runtime: send on closed channel")
 			}
+
+			// Slow-path: enqueue thread to waiters and park.
+			// A thread must notify (might be spurious) this thread.
+			self.lock.lock()
+			if self.closed != 0 {
+				panic("runtime: send on closed channel")
+			}
+			// Last chance, try the lock-free MPMC queue.
+			// When we try to lock the channel mutex, a data might be received from queue.
+			enq, _, _ = self.queue.enqueue(&data)
+			// Enqueued, lucky. Return.
+			if enq {
+				self.lock.unlock()
+				ret
+			}
+			// Send data (hand-off) to a waiting receiver, if any.
+			// Otherwise, park the thread until a thread notify (might be spurious) us.
+			if !self.sendFinal(&data) {
+				// Not a spurious wakeup, return.
+				ret
+			}
+			// Spurious wakeup, we have to try again.
 		}
 	}
 
@@ -73,25 +166,12 @@ impl pchan {
 			panic("runtime: send on closed channel")
 		}
 
-		// Before park the thread, check for a waiting receiver, if any.
-		// If we lucky, write data to the stack of the receiver and return.
-		mut recvp := self.recvq.dequeue()
-		if recvp != nil {
-			self.lock.unlock()
-			unsafe { *(*T)(recvp.stack) = data }
-			recvp.stack = 0 // Set stack pointer to zero, marked as written.
-			recvp.parker.unpark()
-			ret
+		// Unbuffered channels works with direct data hand-off.
+		// No spurious wakeups, but closing channel will notify us spuriously.
+		spurious := self.sendFinal(&data)
+		if spurious {
+			panic("runtime: send on closed channel")
 		}
-
-		// We have to park the thread.
-		mut thread := acquireThread()
-		mut stackp := parkerList{}
-		mut p := unsafe { (&parkerList)(&stackp) }
-		p.parker = thread.parker
-		p.stack = uintptr(&data)
-		self.sendq.enqueue(p)
-		park2(&(*thread), uintptr(&self.lock), &(*p.parker), reasonSend)
 	}
 
 	// Sends the data to the channel.
@@ -105,80 +185,176 @@ impl pchan {
 		}
 	}
 
+	// Tries to send a data to receiver from queue immediately.
+	// Channel lock must be locked and it will not be released before return.
+	#disable nilptr
+	fn trySendImmediate(mut *self, mut &ok: *bool, mut &data: *T) {
+		// Check for a waiting receiver, if any.
+		// If we lucky, write data to the stack of the receiver and return.
+		mut recvp := self.recvq.dequeueChan()
+		if recvp != nil {
+			if recvp.stack != 0 {
+				unsafe { *(*T)(recvp.stack) = *data }
+				recvp.stack = 0 // Set stack pointer to zero, marked as sent.
+			}
+			recvp.ticket = 0 // Set ticket to zero, marked as sent for select statements.
+			recvp.parker.unpark()
+			*ok = true
+		} else {
+			// Fail.
+			*ok = false
+		}
+	}
+
 	// Implementation of the buffered [pchan.trySend] function.
 	#disable nilptr
-	fn trySendBuffered(mut *self, mut data: T): (ok: bool) {
-		mut waitstart := i64(0)
-		for {
-			enq, closed := self.queue.enqueue(&data)
-			if enq {
-				ret true
-			}
-			if closed {
-				ret false
-			}
-			if waitstart == 0 {
-				waitstart = nanotime()
-				continue
-			}
-			// If we tried much, according to chanThreshold,
-			// then consider waiting receivers.
-			if nanotime()-waitstart > chanThreshold {
-				break
+	fn trySendBuffered(mut *self, mut &ok: *bool, mut &data: *T) {
+		// Enqueue data using lock-free MPMC queue.
+		enq, _, full := self.queue.enqueue(data)
+		// If queue is full now (or with new sent data), wake a receiver.
+		// This is a spurious wake, do not write the data to it's stack pointer.
+		// It must be try to receive it from the queue.
+		//
+		// This is needed because all receivers might be parked.
+		// Queue is full and no reader, deadlock. Bad.
+		if full {
+			self.lock.lock()
+			mut recvp := self.recvq.dequeueChan()
+			self.lock.unlock()
+			if recvp != nil {
+				recvp.parker.unpark()
 			}
 		}
-		ret false
+		// Enqueued, return.
+		if enq {
+			*ok = true
+			ret
+		}
+		*ok = false
 	}
 
 	// Implementation of the unbuffered [pchan.trySend] function.
 	#disable nilptr
-	fn trySendUnbuffered(mut *self, mut data: T): (ok: bool) {
+	fn trySendUnbuffered(mut *self, mut &ok: *bool, mut &data: *T) {
 		// Check for a waiting receiver, if any.
 		// If we lucky, write data to the stack of the receiver and return.
 		self.lock.lock()
-		mut recvp := self.recvq.dequeue()
+		mut recvp := self.recvq.dequeueChan()
 		self.lock.unlock()
 		if recvp != nil {
-			unsafe { *(*T)(recvp.stack) = data }
-			recvp.stack = 0 // Set stack pointer to zero, marked as written.
+			if recvp.stack != 0 {
+				unsafe { *(*T)(recvp.stack) = *data }
+				recvp.stack = 0 // Set stack pointer to zero, marked as sent.
+			}
+			recvp.ticket = 0 // Set ticket to zero, marked as sent for select statements.
 			recvp.parker.unpark()
-			ret true
+			*ok = true
+		} else {
+			// Fail.
+			*ok = false
 		}
-
-		// Fail.
-		ret false
 	}
 
 	// Tries to send the data to the channel.
 	// Do not blocks until success.
+	// The `ok` parameter must always not be nil.
 	#disable nilptr
-	fn trySend(mut *self, mut data: T): bool {
+	fn trySend(mut *self, mut &ok: *bool, mut &data: *T) {
 		if self == nil {
-			ret false
+			*ok = false
 		} else if self.cap == 0 {
-			ret self.trySendUnbuffered(data)
+			self.trySendUnbuffered(ok, data)
 		} else {
-			ret self.trySendBuffered(data)
+			self.trySendBuffered(ok, data)
 		}
+	}
+
+	// Final implementation of the [pchan.recv] function.
+	// Focuses on parked threads.
+	// Mutex must be locked. It will be released before return.
+	// Reports whether the stack pointer is used (data handled).
+	#disable nilptr
+	fn recvFinal(mut *self, mut &ok: *bool, mut &data: *T): (spurious: bool) {
+		// Before park the thread, check for a waiting sender, if any.
+		// If we lucky, read data from the stack of the sender and return.
+		mut sendp := self.sendq.dequeueChan()
+		if sendp != nil {
+			self.lock.unlock()
+			*data = unsafe { *(*T)(sendp.stack) }
+			sendp.stack = 0  // Set stack pointer to zero, marked as received.
+			sendp.ticket = 0 // Set ticket to zero, marked as received for select statements.
+			sendp.parker.unpark()
+			if ok != nil {
+				*ok = true
+			}
+			ret false
+		}
+
+		// We have to park the thread.
+		mut thread := acquireThread()
+		mut stackp := parkerList{}
+		mut p := unsafe { (&parkerList)(&stackp) }
+		p.parker = thread.parker
+		p.stack = uintptr(data)
+		self.recvq.enqueue(p)
+		park2(&(*thread), uintptr(&self.lock), &(*p.parker), reasonRecv)
+		spurious = isSpuriousWake(&stackp)
+		if ok != nil {
+			*ok = !spurious
+		}
+		ret
 	}
 
 	// Implementation of the buffered [pchan.recv] function.
 	#disable nilptr
 	fn recvBuffered(mut *self, mut &ok: *bool): (data: T) {
 		for {
-			deq, closed := self.queue.dequeue(&data)
+			// Fast-path: dequeue data using the lock-free MPMC queue.
+			mut deq, mut closed := self.queue.dequeue(&data)
+			// Dequeued, return.
 			if deq {
 				if ok != nil {
 					*ok = true
 				}
 				ret
 			}
+			// Not dequeued and MPMC queue is closed.
+			// This means channel is closed and buffer is empty.
 			if closed {
 				if ok != nil {
 					*ok = false
 				}
 				ret
 			}
+
+			// Slow-path: enqueue thread to waiters and park.
+			// A thread must notify (might be spurious) this thread.
+			self.lock.lock()
+			if self.closed != 0 {
+				self.lock.unlock()
+				if ok != nil {
+					*ok = false
+				}
+				ret
+			}
+			// Last chance, try the lock-free MPMC queue.
+			// When we try to lock the channel mutex, a data might be sent to queue.
+			deq, closed = self.queue.dequeue(&data)
+			// Dequeued, lucky. Return.
+			if deq {
+				self.lock.unlock()
+				if ok != nil {
+					*ok = true
+				}
+				ret
+			}
+			// Receive (hand-off) data from a waiting sender, if any.
+			// Otherwise, park the thread until a thread notify (might be spurious) us.
+			if !self.recvFinal(ok, &data) {
+				// Not a spurious wakeup, return.
+				ret
+			}
+			// Spurious wakeup, we have to try again.
 		}
 	}
 
@@ -196,31 +372,10 @@ impl pchan {
 			ret
 		}
 
-		// Before park the thread, check for a waiting sender, if any.
-		// If we lucky, read data from the stack of the sender and return.
-		mut sendp := self.sendq.dequeue()
-		if sendp != nil {
-			self.lock.unlock()
-			data = unsafe { *(*T)(sendp.stack) }
-			sendp.stack = 0 // Set stack pointer to zero, marked as consumed.
-			sendp.parker.unpark()
-			if ok != nil {
-				*ok = true
-			}
-			ret
-		}
-
-		// We have to park the thread.
-		mut thread := acquireThread()
-		mut stackp := parkerList{}
-		mut p := unsafe { (&parkerList)(&stackp) }
-		p.parker = thread.parker
-		p.stack = uintptr(&data)
-		self.recvq.enqueue(p)
-		park2(&(*thread), uintptr(&self.lock), &(*p.parker), reasonRecv)
-		if ok != nil {
-			*ok = true
-		}
+		// Unbuffered channels works with direct data hand-off.
+		// No spurious wakeups, but closing channel will notify us spuriously.
+		// Is is handled like hand-off but failed.
+		self.recvFinal(ok, &data)
 		ret
 	}
 
@@ -237,69 +392,89 @@ impl pchan {
 		}
 	}
 
-	// Implementation of the buffered [pchan.tryRecv] function.
+	// Tries to receive a data from sender queue immediately.
+	// Channel lock must be locked and it will not be released before return.
+	// The closed state pointer must be not nil.
 	#disable nilptr
-	fn tryRecvBuffered(mut *self, mut &ok: *bool): (data: T) {
-		mut waitstart := i64(0)
-		for {
-			deq, closed := self.queue.dequeue(&data)
-			if deq {
-				*ok = true
-				ret
+	fn tryRecvImmediate(mut *self, mut &ok: *bool, mut &data: *T, mut &closed: *bool) {
+		*closed = self.closed != 0
+		mut sendp := self.sendq.dequeueChan()
+		if sendp != nil {
+			if data != nil {
+				*data = unsafe { *(*T)(sendp.stack) }
 			}
-			if closed {
-				*ok = false
-				ret
-			}
-			if waitstart == 0 {
-				waitstart = nanotime()
-				continue
-			}
-			// If we tried much, according to chanThreshold,
-			// then consider waiting senders.
-			if nanotime()-waitstart > chanThreshold {
-				break
+			sendp.stack = 0  // Set stack pointer to zero, marked as received.
+			sendp.ticket = 0 // Set ticket to zero, marked as received for select statements.
+			sendp.parker.unpark()
+			*ok = true
+		} else {
+			// Fail.
+			*ok = false
+			if data != nil {
+				let mut zero: T
+				*data = zero
 			}
 		}
+	}
+
+	// Implementation of the buffered [pchan.tryRecv] function.
+	// The closed state pointer must be not nil.
+	#disable nilptr
+	fn tryRecvBuffered(mut *self, mut &ok: *bool, mut &data: *T, mut &closed: *bool) {
+		// Dequeue data using the lock-free MPMC queue.
+		deq, (*closed) := self.queue.dequeue(data)
+		if deq {
+			*ok = true
+			ret
+		}
 		*ok = false
-		ret
+		if data != nil {
+			let mut zero: T
+			*data = zero
+		}
 	}
 
 	// Implementation of the unbuffered [pchan.tryRecv] function.
 	#disable nilptr
-	fn tryRecvUnbuffered(mut *self, mut &ok: *bool): (data: T) {
+	fn tryRecvUnbuffered(mut *self, mut &ok: *bool, mut &data: *T, mut &closed: *bool) {
 		// Check for a waiting sender, if any.
 		// If we lucky, read data from the stack of the sender and return.
 		self.lock.lock()
-		mut sendp := self.sendq.dequeue()
+		*closed = self.closed != 0
+		mut sendp := self.sendq.dequeueChan()
 		self.lock.unlock()
 		if sendp != nil {
-			data = unsafe { *(*T)(sendp.stack) }
-			sendp.stack = 0 // Set stack pointer to zero, marked as consumed.
+			if data != nil {
+				*data = unsafe { *(*T)(sendp.stack) }
+			}
+			sendp.stack = 0  // Set stack pointer to zero, marked as received.
+			sendp.ticket = 0 // Set ticket to zero, marked as received for select statements.
 			sendp.parker.unpark()
 			*ok = true
-			ret
+		} else {
+			// Fail.
+			*ok = false
+			if data != nil {
+				let mut zero: T
+				*data = zero
+			}
 		}
-
-		// Fail.
-		*ok = false
-		ret
 	}
 
 	// Tries to receive a data from the channel.
-	// The parameter ok always must be not-nil.
+	// The parameter ok and closed always must be not-nil.
 	#disable nilptr
-	fn tryRecv(mut *self, mut &ok: *bool): T {
+	fn tryRecv(mut *self, mut &ok: *bool, mut &data: *T, mut &closed: *bool) {
 		if self == nil {
-			if ok != nil {
-				*ok = false
+			*ok = false
+			if data != nil {
+				let mut zero: T
+				*data = zero
 			}
-			let mut zero: T
-			ret zero
 		} else if self.cap == 0 {
-			ret self.tryRecvUnbuffered(ok)
+			self.tryRecvUnbuffered(ok, data, closed)
 		} else {
-			ret self.tryRecvBuffered(ok)
+			self.tryRecvBuffered(ok, data, closed)
 		}
 	}
 
@@ -312,26 +487,4 @@ impl pchan {
 		}
 		ret self.cap
 	}
-}
-
-// Empty select statement implementation.
-#disable nilptr
-fn emptyselect() {
-	mut t := acquireThread()
-	t.state |= threadSuspended | reasonSelect | reasonSelectEmpty
-	// Add special case for empty select.
-	threadCases |= threadSC_EmptySelect
-	// Check deadlock before sleep and release mutex.
-	checkDeadlock(0, reasonSelect|reasonSelectEmpty)
-	threadMutex.unlock()
-	// Park thread indefinitely.
-	// We do not need to yield CPU with temporary parking,
-	// this thread will never continue to run.
-	// It always yields CPU due to empty select statement,
-	// so put it into deep sleep. Other threads can caught deadlocks,
-	// if any, after this stage. If this thread is the single thread,
-	// we already checked deadlocks. So put this thread into deep sleep
-	// indefinitely.
-	t.parker.park()
-	panic("unreachable")
 }

--- a/std/runtime/malloc.jule
+++ b/std/runtime/malloc.jule
@@ -60,6 +60,9 @@ const (
 	maxAlloc = (1 << heapAddrBits) - (1-_64bit)*1
 )
 
+// Base pointer for all 0-byte allocations.
+let zerobase: uintptr = 0
+
 // Pseudo memory allocation, for allocation checking and documentation purposes.
 // Any runtime allocation must be follow this implementation documentation.
 // Pseudo allocates linear memory on the heap. The |n| is non-negative count of elements.

--- a/std/runtime/math.jule
+++ b/std/runtime/math.jule
@@ -101,3 +101,10 @@ fn min(x: int, y: int): int {
 	}
 	ret y
 }
+
+fn absint(x: int): int {
+	if x < 0 {
+		ret -x
+	}
+	ret x
+}

--- a/std/runtime/mpmc.jule
+++ b/std/runtime/mpmc.jule
@@ -26,6 +26,7 @@ struct paddedU64 {
 // Implementation based on the Dmitry Vyukov's MPMC queue.
 struct mpmcQueue[T] {
 	cap:    u64
+	act:    u64
 	closed: u32
 	buf:    []mpmcCell[T]
 
@@ -38,12 +39,14 @@ struct mpmcQueue[T] {
 }
 
 impl mpmcQueue {
+	#disable boundary
 	fn new(mut cap: u64): (q: mpmcQueue[T]) {
-		if cap < 2 {
-			cap = 2
-		}
+		q.act = cap
 		q.cap = cap
-		q.buf = make([]mpmcCell[T], cap)
+		if q.cap < 2 {
+			q.cap = 2
+		}
+		q.buf = make([]mpmcCell[T], q.cap)
 
 		// Initialize per-slot sequence numbers to their indices
 		mut i := u64(0)
@@ -56,11 +59,11 @@ impl mpmcQueue {
 	// Attempts to enqueue val; returns false if the queue appears full.
 	// Non-blocking; uses polite backoff on contention.
 	#disable boundary nilptr
-	fn enqueue(mut *self, mut &val: *T): (ok: bool, closed: bool) {
+	fn enqueue(mut *self, mut &val: *T): (ok: bool, closed: bool, full: bool) {
 		for {
 			closed = atomic::Load(&self.closed, atomic::Acquire) != 0
 			if closed {
-				ret false, true
+				ret false, true, false
 			}
 			pos := atomic::Load(&self.enqueuePos.v, atomic::Relaxed)
 			mut &c := unsafe { &(*(&self.buf[pos%self.cap])) }
@@ -69,17 +72,21 @@ impl mpmcQueue {
 
 			if dif == 0 {
 				// slot is EMPTY for this producer position: try to claim it
-				if atomic::CompareAndSwapWeak(&self.enqueuePos.v, pos, pos+1, atomic::SeqCst, atomic::Relaxed) {
+				newPos := pos + 1
+				if atomic::CompareAndSwapWeak(&self.enqueuePos.v, pos, newPos, atomic::SeqCst, atomic::Relaxed) {
 					// exclusive ownership of this slot
 					c.val = *val
+					// check if the buffer is full
+					deqPos := atomic::Load(&self.dequeuePos.v, atomic::Acquire)
+					full = newPos-deqPos == self.act
 					// publish for consumer at pos
-					atomic::Store(&c.seq, pos+1, atomic::Release)
-					ret true, false
+					atomic::Store(&c.seq, newPos, atomic::Release)
+					ret true, false, full
 				}
 				// lost race → retry
 			} else if dif < 0 {
 				// seq < pos ⇒ consumer has not yet advanced for this slot in this wrap; FULL
-				ret false, false
+				ret false, false, true
 			} else {
 				// another producer is ahead / not our turn yet → polite backoff
 				osyield()

--- a/std/runtime/parker.jule
+++ b/std/runtime/parker.jule
@@ -5,20 +5,45 @@
 // For thread parking, Jule runtime uses futex and futex-like APIs.
 // See: https://shift.click/blog/futex-like-apis
 
+use "std/internal/runtime/atomic"
+
+// Special flags for the ticket state.
+const (
+	parkerSelect = iota + 1
+)
+
+// Special flags for the state flags.
+const (
+	parkerSelectWaiting = iota
+	parkerSelectConsumed
+)
+
 // Linked-list for parkers.
 struct parkerList {
 	parker: &parker
+	state:  *int
 	ticket: u32
 	stack:  uintptr
 	next:   &parkerList
 }
 
 struct waitq {
-	head: &parkerList
-	tail: &parkerList
+	mut head: &parkerList
+	tail:     &parkerList
 }
 
 impl waitq {
+	#disable nilptr
+	fn exist(*self, p: &parkerList): bool {
+		mut i := self.head
+		for i != nil; i = i.next {
+			if i == p {
+				ret true
+			}
+		}
+		ret false
+	}
+
 	#disable nilptr
 	fn enqueue(mut *self, mut p: &parkerList) {
 		if self.tail == nil {
@@ -27,6 +52,13 @@ impl waitq {
 			self.tail.next = p
 		}
 		self.tail = p
+	}
+
+	#disable nilptr
+	fn enqueueAvoidDuplicate(mut *self, mut p: &parkerList) {
+		if !self.exist(p) {
+			self.enqueue(p)
+		}
 	}
 
 	#disable nilptr
@@ -42,17 +74,52 @@ impl waitq {
 		p.next = nil
 		ret p
 	}
+
+	// Dequeue according to channel tickets.
+	// If waiter is a select statement thread, skips if it is consumed.
+	#disable nilptr
+	fn dequeueChan(mut *self): &parkerList {
+		for {
+			mut deq := self.dequeue()
+			if deq == nil {
+				ret nil
+			}
+			// If waiter is a select statement, check if it is consumed.
+			// If the state is not zero, thread is consumed.
+			// Set state as consumed to prevent false dequeue.
+			if deq.ticket&parkerSelect == parkerSelect &&
+				!atomic::CompareAndSwap(deq.state, parkerSelectWaiting, parkerSelectConsumed, atomic::AcqRel, atomic::AcqRel) {
+				continue
+			}
+			ret deq
+		}
+	}
 }
 
 // Unparks all threads from the waiters q.
 #disable nilptr
-fn unparkAll(mut &q: *waitq) {
+fn unparkAll(mut &q: *waitq, clearSpuriousSigns: bool) {
 	// Go through the local list and ready all waiters.
 	mut s := q.head
 	for s != nil {
 		mut next := s.next
 		s.next = nil
+		if clearSpuriousSigns {
+			s.stack = 0  // Set stack pointer to zero, marked as received/sent.
+			s.ticket = 0 // Set ticket to zero, marked as received/sent for select statements.
+		}
 		s.parker.unpark()
 		s = next
 	}
+}
+
+// Reports whether the parker is notified spuriously.
+// Implemented for channels and select statements.
+#disable nilptr
+fn isSpuriousWake(&p: *parkerList): bool {
+	// If stack is not zero, it is not consumed.
+	// But select statement may pass zero stack pointer for no receiver memory cases.
+	// Check for the ticket, if ticket is parkerSelect, it is not consumed.
+	// Appropriate consuption will set them to zero.
+	ret p.ticket != 0 || p.stack != 0
 }

--- a/std/runtime/select.jule
+++ b/std/runtime/select.jule
@@ -161,8 +161,25 @@ unsafe fn unlockchans(mut chans: *&uintptr, mut nchan: int) {
 	}
 }
 
+// Implementation of the select statements.
+// Type-independent, single generic implementation for all select statements.
+//
+// The `chans` is pointer to the channel array. Stores all channels used in cases,
+// may include duplicated channels. The `nchan` is length of the `chans` array.
+// The `cases` is pointer to the array, which is contains cases of the select statement.
+// The default case is not included and receivers come first. So if `index < nrecv`,
+// then it is a receiver case. The `nrecv` is count of receiver cases,
+// while `nsend` is count of sender cases. Expression `nrecv + nsend` equals to
+// length of the `cases` array. If the `block` is true, then select statement
+// has no a default case, so blocking.
+//
+// Channels are represented as a generic smart pointer, like `&uintptr`.
+// The underlying type is `&pchan[T]`, it may be used like `&pchan[uintptr]` to
+// reach common fields of the channel. But receive/send methods are cannot be
+// used since this kind of methods are type-dependent. To solve the problem,
+// each case includes function pointers of the underlying channel type.
 #disable nilptr boundary
-unsafe fn runselect(mut chans: *&uintptr, mut nchan: int, mut cases: *scase, mut nrecv: int, nsend: int, block: bool): (index: int) {
+unsafe fn runselect(mut chans: *&uintptr, mut nchan: int, mut cases: *scase, mut nrecv: int, nsend: int, block: bool): int {
 	totalCases := nrecv + nsend
 	k := absint(int(rand()))
 
@@ -282,7 +299,6 @@ unsafe fn runselect(mut chans: *&uintptr, mut nchan: int, mut cases: *scase, mut
 	// First, parks the thread.
 	// When notified, returns immediately if channel notified after hand-off.
 	// If a channel notified spuriously, try again and park it, if it fails.
-
 	for {
 		// Unlock channels and park the thread.
 		unlockchans(chans, nchan)

--- a/std/runtime/select.jule
+++ b/std/runtime/select.jule
@@ -1,0 +1,406 @@
+// Copyright 2025 The Jule Project Contributors. All rights reserved.
+// Use of this source code is governed by a BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+use "std/internal/runtime/atomic"
+use "std/sys"
+
+// Select case.
+struct scase {
+	// General channel pointer. Can be cast to `&pchan[uintptr]`.
+	// Nil channels are allowed.
+	// The queue field must not be used in select statement.
+	// Algorithm must be type-independent.
+	ch: *&uintptr
+
+	// Method addresses of the specific channel type.
+	// This is an abstraction empowered by the compiler.
+	// `tryRecv` points to the `pchan[T].tryRecv`
+	// `tryRecvImmediate` points to the `pchan[T].tryRecvImmediate`
+	// `trySend` points to the `pchan[T].trySend`
+	// `trySendImmediate` points to the `pchan[T].trySendImmediate`
+	tryRecv:          uintptr
+	tryRecvImmediate: uintptr
+	trySend:          uintptr
+	trySendImmediate: uintptr
+
+	// Stack pointer to be received/sent data.
+	// For receive operations, recieved data will be ignored if it is zero.
+	// For send operations, zero pointer is undefined behavior.
+	data: uintptr
+}
+
+// Empty select statement implementation.
+#disable nilptr
+fn emptyselect() {
+	mut t := acquireThread()
+	t.state |= threadSuspended | reasonSelect | reasonSelectEmpty
+	// Add special case for empty select.
+	threadCases |= threadSC_EmptySelect
+	// Check deadlock before sleep and release mutex.
+	checkDeadlock(0, reasonSelect|reasonSelectEmpty)
+	threadMutex.unlock()
+	// Park thread indefinitely.
+	// We do not need to yield CPU with temporary parking,
+	// this thread will never continue to run.
+	// It always yields CPU due to empty select statement,
+	// so put it into deep sleep. Other threads can caught deadlocks,
+	// if any, after this stage. If this thread is the single thread,
+	// we already checked deadlocks. So put this thread into deep sleep
+	// indefinitely.
+	t.parker.park()
+	panic("unreachable")
+}
+
+// Basic QuickSort for generic chan array.
+#disable nilptr
+unsafe fn sortchans(mut chans: *&uintptr, nchan: int) {
+	// Base case: If the array has 0 or 1 element, it is already sorted.
+	if (nchan < 2) {
+		ret
+	}
+
+	// 1. Choose the pivot.
+	// We choose the last element as the pivot for simplicity.
+	// The pivot element is at chans[nchan - 1].
+	mut pivotPtr := chans + nchan - 1
+	pivotValue := uintptr(*pivotPtr)
+
+	// 2. Partitioning the array.
+	// 'iPtr' will track the boundary of elements smaller than the pivot.
+	// Start iPtr one position before the start of the current segment.
+	mut iPtr := chans - 1
+
+	// 'jPtr' iterates through all elements up to the pivot (chans[0] to chans[nchan-2]).
+	// Loop condition: jPtr < pivotPtr (equivalent to jPtr <= chans + nchan - 2)
+	mut jPtr := chans
+	for jPtr < pivotPtr; jPtr++ {
+		// If the current element is less than or equal to the pivot
+		if (uintptr(*jPtr) <= pivotValue) {
+			// Move the boundary 'iPtr' one step forward
+			iPtr++
+			// Swap the element at jPtr with the element at the new iPtr position.
+			// This moves elements smaller than the pivot to the front.
+			*iPtr, *jPtr = *jPtr, *iPtr
+		}
+	}
+
+	// 3. Place the pivot in its correct sorted position.
+	// The pivot should be placed right after the last element smaller than it,
+	// which is the element pointed to by 'iPtr'.
+	iPtr++                              // Move iPtr to the position where the pivot should go.
+	*iPtr, *pivotPtr = *pivotPtr, *iPtr // Swap the pivot (which was at chans[nchan-1]) with *iPtr.
+
+	// 'iPtr' now points to the pivot in its final, sorted position.
+	// This is the separation point for the two subproblems.
+
+	// Calculate the sizes for the two recursive calls.
+	// The first subarray is from 'chans' up to (but not including) the pivot.
+	// Its length is the difference between the pivot's new address and the start address.
+	lenLeft := int(iPtr - chans)
+
+	// The second subarray is from the element *after* the pivot to the end.
+	// Its length is the total length minus the length of the left part and minus the pivot itself.
+	lenRight := int(nchan - lenLeft - 1)
+
+	// 4. Recursive calls for the two subarrays.
+	// Recursively sort the elements to the left of the pivot.
+	sortchans(chans, lenLeft)
+
+	// Recursively sort the elements to the right of the pivot.
+	// The new starting pointer is the element right after the pivot (*iPtr + 1).
+	sortchans(iPtr+1, lenRight)
+}
+
+// Converts general pointer to the general channel type.
+unsafe fn unpackchan(mut p: *&uintptr): *&pchan[uintptr] {
+	ret (*&pchan[uintptr])(p)
+}
+
+// Locks channels.
+// Avois locking duplicate channels.
+// Must be sorted by address.
+#disable nilptr
+unsafe fn lockchans(mut chans: *&uintptr, mut nchan: int) {
+	let mut last: uintptr
+	nchan--
+	for nchan >= 0; nchan-- {
+		// Skip duplicate channels.
+		// Otherwise, we will try to lock already locked mutex.
+		// Deadlock.
+		if uintptr(chans[nchan]) == last {
+			continue
+		}
+		ch := unpackchan(chans + nchan)
+		if *ch != nil {
+			(*ch).lock.lock()
+			last = uintptr(chans[nchan])
+		}
+	}
+}
+
+// Unlocks channels.
+// Avois locking duplicate channels.
+// Must be sorted by address.
+#disable nilptr
+unsafe fn unlockchans(mut chans: *&uintptr, mut nchan: int) {
+	let mut last: uintptr
+	nchan--
+	for nchan >= 0; nchan-- {
+		// Skip duplicate channels.
+		// Otherwise, we will try to lock already locked mutex.
+		// Deadlock.
+		if uintptr(chans[nchan]) == last {
+			continue
+		}
+		ch := unpackchan(chans + nchan)
+		if *ch != nil {
+			(*ch).lock.unlock()
+			last = uintptr(chans[nchan])
+		}
+	}
+}
+
+#disable nilptr boundary
+unsafe fn runselect(mut chans: *&uintptr, mut nchan: int, mut cases: *scase, mut nrecv: int, nsend: int, block: bool): (index: int) {
+	totalCases := nrecv + nsend
+	k := absint(int(rand()))
+
+	// Fast-path: try channels for receive/send.
+	// If we hit a case, select it and return immediately.
+	// Use round-robin iteration to achieve randomness.
+	mut j := 0
+	for j < totalCases; j++ {
+		offset := (k + j) % totalCases
+		case := cases + offset
+
+		// Skip if channel is nil.
+		if *case.ch == nil {
+			continue
+		}
+
+		mut ok := false
+		if offset < nrecv {
+			// Case is a receive operation.
+			mut closed := false
+			sys::Addrcall(case.tryRecv, (*unsafe)(uintptr(*case.ch)), &ok, (*unsafe)(case.data), &closed)
+			ok = ok || closed
+		} else {
+			// Case is a send operation.
+			sys::Addrcall(case.trySend, (*unsafe)(uintptr(*case.ch)), &ok, (*unsafe)(case.data))
+		}
+		if ok {
+			ret offset
+		}
+	}
+	// No suitable candidate.
+	// Return if select statement is not blocking.
+	if !block {
+		ret totalCases
+	}
+	// Slow-path: we have to park the thread until one of the channels notify us.
+
+	// Sort channels. Thus, we can manage them easilly.
+	sortchans(chans, nchan)
+
+	// Lock channels.
+	lockchans(chans, nchan)
+
+	// Before we lock the channels, a new receiver/sender may be enqueued.
+	// Check for waiters and return immediately, if possible.
+	// Use round-robin iteration to achieve randomness.
+	j = 0
+	for j < totalCases; j++ {
+		offset := (k + j) % totalCases
+		mut case := cases + offset
+
+		// Skip if channel is nil.
+		if *case.ch == nil {
+			continue
+		}
+
+		mut ok := false
+		if offset < nrecv {
+			// Case is a receive operation.
+			mut closed := false
+			sys::Addrcall(case.tryRecvImmediate, (*unsafe)(uintptr(*case.ch)), &ok, (*unsafe)(case.data), &closed)
+			ok = ok || closed
+		} else {
+			// Case is a send operation.
+			sys::Addrcall(case.trySendImmediate, (*unsafe)(uintptr(*case.ch)), &ok, (*unsafe)(case.data))
+		}
+		if ok {
+			unlockchans(chans, nchan)
+			ret offset
+		}
+	}
+	// There is no waiter in the queue.
+	// We have to park this thread, eventually.
+
+	// Allocate and prepare a parker per operation.
+	// Do not assign thread yet, avoid making busy the mutex for a long time.
+	// Use round-robin iteration to achieve randomness.
+	mut parkers := make([]parkerList, nrecv+nsend)
+	mut state := parkerSelectWaiting
+	for i in parkers {
+		offset := ((k + i) % totalCases)
+		mut case := cases + offset
+		mut parker := &parkers[offset]
+
+		// Skip if channel is nil.
+		if *case.ch == nil {
+			continue
+		}
+
+		mut ch := unpackchan(case.ch)
+
+		// Skip if channel is closed.
+		if (*ch).closed != 0 {
+			continue
+		}
+
+		// Prepare and enqeueue parker.
+		parker.ticket = parkerSelect
+		parker.state = &state // Use shared state pointer for all parkers.
+		parker.stack = case.data
+		if i < nrecv {
+			(*ch).recvq.enqueue((&parkerList)(parker))
+		} else {
+			(*ch).sendq.enqueue((&parkerList)(parker))
+		}
+	}
+
+	// We can acquire the current thread and assign it to parkers.
+	// All parkers will use the current thread.
+	// Any notification will unpark the select statement.
+	mut thread := acquireThread()
+	for i in parkers {
+		parkers[i].parker = thread.parker
+	}
+
+	// Park and try iteration.
+	// First, parks the thread.
+	// When notified, returns immediately if channel notified after hand-off.
+	// If a channel notified spuriously, try again and park it, if it fails.
+
+	for {
+		// Unlock channels and park the thread.
+		unlockchans(chans, nchan)
+		park2(&(*thread), 0, &(*thread.parker), reasonSelect)
+
+		// Look for the selected channel.
+		for i in parkers {
+			if !isSpuriousWake(&(*(&parkers[i]))) {
+				ret i // Return position of the handled channel.
+			}
+		}
+
+		// Exact spurious wakeup.
+		// Try all possible channels.
+		// We can do it lock-free, spurious wakeups may occur only on buffered channels.
+		// Unbuffered channels may be notified spuriously when closing channel,
+		// but this will result as no-data receive. In the final, it is not spurious.
+		// We can try unbuffered channels only, which is lock-free.
+		// Use round-robin iteration to achieve randomness.
+		j = 0
+		for j < totalCases; j++ {
+			offset := (k + j) % totalCases
+			mut case := cases + offset
+
+			// Skip if channel is nil.
+			if *case.ch == nil {
+				continue
+			}
+
+			mut ch := unpackchan(case.ch)
+
+			// Skip if channel is unbuffered.
+			if (*ch).cap == 0 {
+				continue
+			}
+
+			mut ok := false
+			if offset < nrecv {
+				// Case is a receive operation.
+				mut closed := false
+				sys::Addrcall(case.tryRecv, (*unsafe)(uintptr(*case.ch)), &ok, (*unsafe)(case.data), &closed)
+				ok = ok || closed
+			} else {
+				// Case is a send operation.
+				sys::Addrcall(case.trySend, (*unsafe)(uintptr(*case.ch)), &ok, (*unsafe)(case.data))
+			}
+			if ok {
+				ret offset
+			}
+		}
+
+		// Lock channels.
+		lockchans(chans, nchan)
+
+		// Before we lock the channels, a new receiver/sender may be enqueued.
+		// Check for waiters and return immediately, if possible.
+		// Use round-robin iteration to achieve randomness.
+		j = 0
+		for j < totalCases; j++ {
+			offset := (k + j) % totalCases
+			mut case := cases + offset
+
+			// Skip if channel is nil.
+			if *case.ch == nil {
+				continue
+			}
+
+			mut ok := false
+			if offset < nrecv {
+				// Case is a receive operation.
+				mut closed := false
+				sys::Addrcall(case.tryRecvImmediate, (*unsafe)(uintptr(*case.ch)), &ok, (*unsafe)(case.data), &closed)
+				ok = ok || closed
+			} else {
+				// Case is a send operation.
+				sys::Addrcall(case.trySendImmediate, (*unsafe)(uintptr(*case.ch)), &ok, (*unsafe)(case.data))
+			}
+			if ok {
+				unlockchans(chans, nchan)
+				ret offset
+			}
+		}
+		// Failure. We have to park thread again, unfortunately.
+
+		// Update state as waiting for all channels.
+		// Since the state variable only handled in lock and we have locked all channels,
+		// there is no consumption risk before we park.
+		atomic::Store(&state, parkerSelectWaiting, atomic::Release)
+
+		// Enqueue parkers again, if needed.
+		// Some channels may drop our parkers while we try channels.
+		// Use round-robin iteration to achieve randomness.
+		for i in parkers {
+			offset := ((k + i) % totalCases)
+			mut case := cases + offset
+			mut parker := &parkers[offset]
+
+			// Skip if channel is nil.
+			if *case.ch == nil {
+				continue
+			}
+
+			mut ch := unpackchan(case.ch)
+
+			// Skip if channel is closed.
+			if (*ch).closed != 0 {
+				continue
+			}
+
+			// Use [enqueueAvoidDuplicate] to avoid enqueue same parker.
+			if i < nrecv {
+				(*ch).recvq.enqueueAvoidDuplicate((&parkerList)(parker))
+			} else {
+				(*ch).sendq.enqueueAvoidDuplicate((&parkerList)(parker))
+			}
+		}
+
+		// Acquire the thread mutex before park.
+		threadMutex.lock()
+	}
+}


### PR DESCRIPTION
## Reimplement Channels

This PR re-implements channels and `select` statements. The reason is to keep performance optimal across a wider range of conditions and to improve future development experience. The current implementation has issues in several areas, and these needed to be addressed.

### Channels

In the current implementation, channels (especially buffered ones) were optimized for high-frequency messaging. An MPMC queue was used for this purpose, but there were still issues that could lead to CPU waste under certain conditions. The most prominent of these was busy-spin waiting.

Buffered channels continuously attempt to dequeue or enqueue data. Even short periods of reduced messaging throughput can cause this waiting loop to degrade into pure CPU waste.

In the new implementation, buffered channels now use a thread-parking strategy similar to unbuffered channels. When message throughput is not sufficiently high, a thread will park itself instead of repeatedly spinning on the queue. This prevents unnecessary CPU waste and allows the system to remain efficient even when traffic temporarily slows down.

### Select Statements

The current implementation operated in a busy-wait manner based on the existing channel implementation. This clearly leads to the same issues described in the channel section. The new implementation has been updated to use a thread-park strategy.

There is also an important change in the memory model. The current implementation was a fully compiler-implemented inline algorithm. The new implementation is now implemented through a runtime function with compiler-empowered abstractions. This will clearly make future changes easier; in most cases, modifying the algorithm of the select statements is equivalent to modifying only the runtime code. In addition, everything is computed once. In the current implementation, channels and the values being sent are recomputed on every attempt. The new implementation computes them once before the select statement is executed and stores them in memory.

### Minor Improvements

- fix: when a channel is closed, sometimes sender threads may not panic
- fix: receiver threads may sometimes report `ok` variable as `true` when woken up due to closing channel

> The Manual has been updated according to this implementation.