### PR TITLE
julec: correct "error" pluralization in error count message

### DIFF
--- a/src/julec/handle/logger.jule
+++ b/src/julec/handle/logger.jule
@@ -81,7 +81,13 @@ impl Logger {
 			Logger.Log(&l)
 		}
 		print("=== ")
-		print(conv::Itoa(len(*logs)))
-		println(" error generated ===")
+		errorCount := len(*logs)
+		print(conv::Itoa(errorCount))
+		if errorCount == 1 {
+			print(" error")
+		} else {
+			print(" errors")
+		}
+		println(" generated ===")
 	}
 }


### PR DESCRIPTION
<!--
    Thank you for contributing to Jule project!
    Be sure to follow our Code of Conduct and contributing guidelines, and fill in the details below.

    Contributing Guidelines: https://jule.dev/contribute
-->

### Description

Corrects a grammar issue where "2 error generated" was displayed
instead of "2 errors generated".

### Checklist

<!-- Check the boxes below to ensure you have completed the checklist. -->

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing tests pass.
- [x] The code follows the code style and conventions of the project.
- [x] No plagiarized, duplicated, or repetitive code that has been directly copied from another source.
- [x] I have read the whole [Contributing Guidelines](https://jule.dev/contribute) of the project and its resources/related pages.
